### PR TITLE
Support building statically linked libraries and disabling FetchContent.

### DIFF
--- a/CMake/FetchGlad.cmake
+++ b/CMake/FetchGlad.cmake
@@ -26,6 +26,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+option( OTK_FETCH_CONTENT "Use FetchContent for third party libraries" ON )
+if( NOT OTK_FETCH_CONTENT )
+  find_package( glad REQUIRED )
+  return()
+endif()
+
 include(FetchContent)
 
 set( GLAD_INSTALL OFF CACHE BOOL "Generate glad installation target" )

--- a/CMake/FetchGlfw.cmake
+++ b/CMake/FetchGlfw.cmake
@@ -26,6 +26,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+option( OTK_FETCH_CONTENT "Use FetchContent for third party libraries" ON )
+if( NOT OTK_FETCH_CONTENT )
+  find_package( glfw3 REQUIRED )
+  return()
+endif()
+
 set( GLFW_BUILD_DOCS OFF CACHE BOOL "Build the GLFW documentation" )
 set( GLFW_BUILD_EXAMPLES OFF CACHE BOOL "Build the GLFW example programs" )
 set( GLFW_BUILD_TESTS OFF CACHE BOOL "Build the GLFW test programs" )

--- a/CMake/FetchGtest.cmake
+++ b/CMake/FetchGtest.cmake
@@ -26,6 +26,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+option( OTK_FETCH_CONTENT "Use FetchContent for third party libraries" ON )
+if( NOT OTK_FETCH_CONTENT )
+  find_package( GTest REQUIRED )
+  return()
+endif()
+
 include(FetchContent)
 
 set( INSTALL_GTEST OFF CACHE BOOL "Enable installation of googletest" )

--- a/CMake/FetchOpenEXR.cmake
+++ b/CMake/FetchOpenEXR.cmake
@@ -26,6 +26,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+option( OTK_FETCH_CONTENT "Use FetchContent for third party libraries" ON )
+if( NOT OTK_FETCH_CONTENT )
+  find_package( OpenEXR 3.1 REQUIRED )
+  return()
+endif()
+
 include(FetchContent)
 
 FetchContent_Declare(

--- a/DemandLoading/CMakeLists.txt
+++ b/DemandLoading/CMakeLists.txt
@@ -49,7 +49,9 @@ if(PROJECT_IS_TOP_LEVEL)
   find_package(OptiXToolkit REQUIRED)
 endif()
 
-add_library( DemandLoading SHARED
+option( BUILD_SHARED_LIBS "Build using shared libraries" ON )
+
+add_library( DemandLoading
   src/DemandLoaderImpl.cpp
   src/DemandLoaderImpl.h
   src/DeviceContextImpl.cpp

--- a/DemandLoading/tests/TestTextureFootprint.cpp
+++ b/DemandLoading/tests/TestTextureFootprint.cpp
@@ -36,8 +36,8 @@
 
 #include <optix.h>
 #include <optix_function_table_definition.h>
-#include <optix_stack_size.h>
 #include <optix_stubs.h>
+#include <optix_stack_size.h>
 #include <optix_types.h>
 
 #include <gtest/gtest.h>

--- a/Gui/CMakeLists.txt
+++ b/Gui/CMakeLists.txt
@@ -44,7 +44,9 @@ if(PROJECT_IS_TOP_LEVEL)
   find_package(OptiXToolkit REQUIRED)
 endif()
 
-add_library(Gui SHARED
+option( BUILD_SHARED_LIBS "Build using shared libraries" ON )
+
+add_library(Gui
   src/Camera.cpp
   src/GLCheck.cpp
   src/GLDisplay.cpp
@@ -78,7 +80,7 @@ target_link_libraries(Gui
   OptiXToolkit::Util
   PRIVATE
   glfw
-  glad
+  glad::glad
   )
 
 set_target_properties(Gui PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/ImageSource/CMakeLists.txt
+++ b/ImageSource/CMakeLists.txt
@@ -45,7 +45,9 @@ if(PROJECT_IS_TOP_LEVEL)
   find_package(OptiXToolkit REQUIRED)
 endif()
 
-add_library( ImageSource SHARED
+option( BUILD_SHARED_LIBS "Build using shared libraries" ON )
+
+add_library( ImageSource
   src/CheckerBoardImage.cpp
   src/CoreEXRReader.cpp
   src/DeviceConstantImage.cpp

--- a/README.md
+++ b/README.md
@@ -43,6 +43,57 @@ make -j
 
 If you encounter problems or if you have any questions, we encourage you to post on the [OptiX developer forum](https://forums.developer.nvidia.com/c/gaming-and-visualization-technologies/visualization/optix/167).
 
+### Building statically linked libraries
+
+OptiX Toolkit components are compiled into dynamic libraries (DSOs/DLLs) to simplify linking client
+applications.  This eliminates the need for client applications to link with third-party libraries
+like OpenEXR and GLFW.
+
+Some clients of the OptiX Toolkit might prefer to use statically linked libraries.  This can be accomplished
+by setting the CMake configuration variable `BUILD_SHARED_LIBS=OFF`.
+
+Important: when building statically linked libraries, the CMake configuration variable
+`OTK_FETCH_CONTENT` should be set to `OFF`, and various third party libraries must be installed as
+described below.
+
+### Installing third-party libraries.
+
+Normally the OptiX Toolkit CMake files use `FetchContent` to download and build various third-party
+libraries:
+- Imath 3.1.5 or later
+- OpenEXR 3.1.5 or later
+- GLFW 3.3 or later
+- glad (any recent version)
+
+This behavior can be disabled by setting `OTK_FETCH_CONTENT=OFF` during CMake configuration,
+which is necessary when building statically linked libraries, as described above.
+
+When `FetchContent` is disabled, the following CMake configuration variables should be used to
+specify the locations of the third-party libraries: `Imath_DIR`, `OpenEXR_DIR`, `glfw3_DIR`, and
+`glad_DIR`.  The directory specified for each of these variables should be the location of the
+project's CMake configuration file.  For example:
+```
+cd build
+cmake \
+-DBUILD_SHARED_LIBS=OFF \
+-DOTK_FETCH_CONTENT=OFF \
+-DImath_DIR=/usr/local/Imath/lib/cmake/Imath \
+-DOpenEXR_DIR=/usr/local/OpenEXR/lib/cmake/OpenEXR \
+-Dglfw3_DIR=/usr/local/glfw3/lib/cmake/glfw3 \
+-Dglad_DIR=/usr/local/glad/lib/cmake/glad \
+-DOptiX_ROOT_DIR=/usr/local/OptiX-SDK-7.5 \
+..
+```
+
+As of this writing, OpenEXR 3.1 binaries are not yet available via most package managers, so we
+recommend building these third party libraries from source code downloaded from the following
+locations:
+
+- Imath 3.1.5: https://github.com/AcademySoftwareFoundation/Imath.git
+- OpenEXR 3.1.5: https://github.com/AcademySoftwareFoundation/openexr.git
+- GLFW 3.3: https://github.com/glfw/glfw.git
+- glad: https://github.com/Dav1dde/glad
+
 ## Troubleshooting
 
 Problem: CMake configuration error: "could not find git for clone of glad-populate" <br>

--- a/Util/CMakeLists.txt
+++ b/Util/CMakeLists.txt
@@ -45,7 +45,9 @@ set(OptiX_INSTALL_DIR "OptiX_INSTALL_DIR-NOTFOUND" CACHE PATH "Path to OptiX ins
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../CMake)
 find_package(OptiX REQUIRED)
 
-add_library(Util SHARED
+option( BUILD_SHARED_LIBS "Build using shared libraries" ON )
+
+add_library(Util
   src/Exception.cpp
   src/Files.cpp
   )

--- a/Util/src/Exception.cpp
+++ b/Util/src/Exception.cpp
@@ -28,7 +28,6 @@
 
 #include <OptiXToolkit/Util/Exception.h>
 
-#include <optix_function_table_definition.h>
 #include <optix_stubs.h>
 
 #include <iostream>

--- a/examples/DemandLoading/Texture/CMakeLists.txt
+++ b/examples/DemandLoading/Texture/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries( demandLoadTexture
   OptiXToolkit::DemandLoading
   OptiXToolkit::Gui
   OptiXToolkit::Util
-  glad
+  glad::glad
   )
 
 set_target_properties( demandLoadTexture PROPERTIES INSTALL_RPATH ${OptiXToolkit_DIR}/../../OptiXToolkit )


### PR DESCRIPTION
FetchContent can be disabled by setting OTK_FETCH_CONTENT=OFF. This is necessary when setting BUILD_SHARED_LIBS=OFF. Closes #3.