### PR TITLE
Fix /EHsc flag confusing NVCC in OTK_FETCH_CONTENT=OFF builds

### DIFF
--- a/CMake/FetchOpenEXR.cmake
+++ b/CMake/FetchOpenEXR.cmake
@@ -29,38 +29,37 @@
 option( OTK_FETCH_CONTENT "Use FetchContent for third party libraries" ON )
 if( NOT OTK_FETCH_CONTENT )
   find_package( OpenEXR 3.1 REQUIRED )
-  return()
+else()
+  include(FetchContent)
+
+  FetchContent_Declare(
+    Imath
+    GIT_REPOSITORY https://github.com/AcademySoftwareFoundation/Imath.git
+    GIT_TAG v3.1.5
+  )
+  FetchContent_MakeAvailable(Imath)
+
+  # Note: Imath does not permit installation to be disabled.
+  # set( IMATH_INSTALL OFF CACHE BOOL "Install Imath" )
+
+  set( OPENEXR_BUILD_EXAMPLES OFF CACHE BOOL "Enables building of utility programs" )
+  set( OPENEXR_BUILD_TOOLS OFF CACHE BOOL "Enables building of utility programs" )
+
+  set( OPENEXR_INSTALL OFF CACHE BOOL "Install OpenEXR libraries" )
+  set( OPENEXR_INSTALL_EXAMPLES OFF CACHE BOOL "Install OpenEXR examples" )
+  set( OPENEXR_INSTALL_TOOLS OFF CACHE BOOL "Install OpenEXR examples" )
+
+  # Note: disabling pkgconfig installation appears to have no effect.
+  set( IMATH_INSTALL_PKG_CONFIG OFF CACHE BOOL "Install Imath.pc file" )
+  set( OPENEXR_INSTALL_PKG_CONFIG OFF CACHE BOOL "Install OpenEXR.pc file" )
+
+  FetchContent_Declare(
+    OpenEXR
+    GIT_REPOSITORY https://github.com/AcademySoftwareFoundation/openexr.git
+    GIT_TAG v3.1.5
+  )
+  FetchContent_MakeAvailable(OpenEXR)
 endif()
-
-include(FetchContent)
-
-FetchContent_Declare(
-  Imath
-  GIT_REPOSITORY https://github.com/AcademySoftwareFoundation/Imath.git
-  GIT_TAG v3.1.5
-)
-FetchContent_MakeAvailable(Imath)
-
-# Note: Imath does not permit installation to be disabled.
-# set( IMATH_INSTALL OFF CACHE BOOL "Install Imath" )
-
-set( OPENEXR_BUILD_EXAMPLES OFF CACHE BOOL "Enables building of utility programs" )
-set( OPENEXR_BUILD_TOOLS OFF CACHE BOOL "Enables building of utility programs" )
-
-set( OPENEXR_INSTALL OFF CACHE BOOL "Install OpenEXR libraries" )
-set( OPENEXR_INSTALL_EXAMPLES OFF CACHE BOOL "Install OpenEXR examples" )
-set( OPENEXR_INSTALL_TOOLS OFF CACHE BOOL "Install OpenEXR examples" )
-
-# Note: disabling pkgconfig installation appears to have no effect.
-set( IMATH_INSTALL_PKG_CONFIG OFF CACHE BOOL "Install Imath.pc file" )
-set( OPENEXR_INSTALL_PKG_CONFIG OFF CACHE BOOL "Install OpenEXR.pc file" )
-
-FetchContent_Declare(
-  OpenEXR
-  GIT_REPOSITORY https://github.com/AcademySoftwareFoundation/openexr.git
-  GIT_TAG v3.1.5
-)
-FetchContent_MakeAvailable(OpenEXR)
 
 # Multiple OpenEXR targets have a compile option (/EHsc) that confuses nvcc.
 # We replace it with $<$<COMPILE_LANGUAGE:CXX>:/EHsc>.


### PR DESCRIPTION
When building with `OTK_FETCH_CONTENT=OFF`, I hit the same issue that seems to have been hit before where the `/EHsc` flag, which comes from OpenEXR, is confusing NVCC. Spitting out the following error,
```
"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\bin\nvcc.exe" -gencode=arch=compute_60,code=\"compute_60,compute_60\" --use-local-env -ccbin "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.26.28801\bin\HostX64\x64" -x cu   -IK:\ImageSource\include -IK:\ImageSource\src -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\include" -I"C:\openexr\include" -I"C:\openexr\include\OpenEXR" -I"C:openexr\include\Imath" -I"C:zlib\include" -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\include"     --keep-dir x64\Release -maxrregcount=0  --machine 64 --compile -cudart static /EHsc -Xcompiler="/EHsc -Ob2"    -D_WINDOWS -DNDEBUG -DOPTIX_SAMPLE_USE_CORE_EXR -DOTK_IMF_NAMESPACE=Imf_3_1 -DNOMINMAX -D"CMAKE_INTDIR=\"Release\"" -D_MBCS -D_ITERATOR_DEBUG_LEVEL=0 -DNDEBUG -DOPTIX_SAMPLE_USE_CORE_EXR -DOTK_IMF_NAMESPACE=Imf_3_1 -DNOMINMAX -D"CMAKE_INTDIR=\"Release\"" -Xcompiler "/EHsc /W1 /nologo /O2 /FdImageSource.dir\Release\ImageSource.pdb /FS   /MD /GR" -o ImageSource.dir\Release\DeviceConstantImageKernels.obj "K:\ImageSource\src\DeviceConstantImageKernels.cu"
nvcc fatal   : A single input file is required for a non-link phase when an outputfile is specified
```
I noticed there was some logic already written to fix this, so I have simply moved some conditions around so that this gets run regardless of if `OTK_FETCH_CONTENT` is on or off.