### PR TITLE
Fix building test on VS 2019

### DIFF
--- a/CuOmmBaking/tests/Util/BakeTexture.h
+++ b/CuOmmBaking/tests/Util/BakeTexture.h
@@ -30,6 +30,7 @@
 
 #include <cuda.h>
 #include <optix.h>
+#include <cstdint>
 
 struct TextureToStateParams
 {


### PR DESCRIPTION
Added cstdint include, otherwise it fails to compile BakeTexture.cu using VS 2019 (16.6.5).