### PR TITLE
Fixes to embed_cuda

### DIFF
--- a/DemandLoading/DemandLoading/tests/TestTextureFootprint.cpp
+++ b/DemandLoading/DemandLoading/tests/TestTextureFootprint.cpp
@@ -313,9 +313,21 @@ class TextureFootprintFixture
             OptixPipelineCompileOptions pipeline_compile_options = {};
             {
                 OptixModuleCompileOptions module_compile_options = {};
-                module_compile_options.maxRegisterCount          = OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT;
-                module_compile_options.optLevel                  = OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
-                module_compile_options.debugLevel                = OPTIX_COMPILE_DEBUG_LEVEL_DEFAULT;
+#ifdef NDEBUG
+                bool debugInfo{ false };
+#else
+                bool debugInfo{ true };
+#endif
+                module_compile_options.optLevel         = debugInfo ? OPTIX_COMPILE_OPTIMIZATION_LEVEL_0 :
+                                                                      OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
+#if OPTIX_VERSION >= 70400
+                module_compile_options.debugLevel       = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL :
+                                                                      OPTIX_COMPILE_DEBUG_LEVEL_MINIMAL;
+#else
+                module_compile_options.debugLevel       = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL :
+                                                                      OPTIX_COMPILE_DEBUG_LEVEL_LINEINFO;
+#endif
+                module_compile_options.maxRegisterCount = OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT;
 
                 pipeline_compile_options.usesMotionBlur        = false;
                 pipeline_compile_options.traversableGraphFlags = OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_LEVEL_INSTANCING;

--- a/OmmBaking/tests/Util/OptiXScene.cpp
+++ b/OmmBaking/tests/Util/OptiXScene.cpp
@@ -440,9 +440,21 @@ OptixResult OptixOmmScene::buildPipeline( const char* optixirInput, const size_t
 
     // Compile modules
     OptixModuleCompileOptions moduleCompileOptions = {};
-    moduleCompileOptions.maxRegisterCount          = OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT;
-    moduleCompileOptions.optLevel                  = OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
-    moduleCompileOptions.debugLevel                = OPTIX_COMPILE_DEBUG_LEVEL_MINIMAL;
+#ifdef NDEBUG
+    bool debugInfo{ false };
+#else
+    bool debugInfo{ true };
+#endif
+    moduleCompileOptions.optLevel   = debugInfo ? OPTIX_COMPILE_OPTIMIZATION_LEVEL_0 :
+                                                    OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
+#if OPTIX_VERSION >= 70400
+    moduleCompileOptions.debugLevel = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL :
+                                                    OPTIX_COMPILE_DEBUG_LEVEL_MINIMAL;
+#else
+    moduleCompileOptions.debugLevel = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL :
+                                                    OPTIX_COMPILE_DEBUG_LEVEL_LINEINFO;
+#endif
+    moduleCompileOptions.maxRegisterCount = OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT;
 
     OptixPipelineCompileOptions pipelineCompileOptions      = {};
     pipelineCompileOptions.usesMotionBlur                   = false;


### PR DESCRIPTION
This change achieves the following:

- removes the DEBUG parameter from embed_cuda
- uses generator expressions to automatically add the correct -g or -lineinfo flags to target_compile_options based on the value of the CMake 'CONFIG' generator expression
- on Windows, embed_cuda creates a unique source file based on the value of CMake 'CONFIG'
- Adds checks to two targets to properly set OptixModuleCompileOptions based on value of NDEBUG and OptiX version

This change has been tested on Ubuntu 24 and Windows 11 for CMAKE_BUILD_TYPE = Release, RelWithDebInfo, and Debug