### PR TITLE
Coalesce redundant textures and white/black texture tiles

### DIFF
--- a/DemandLoading/DemandLoading/include/OptiXToolkit/DemandLoading/Options.h
+++ b/DemandLoading/DemandLoading/include/OptiXToolkit/DemandLoading/Options.h
@@ -30,6 +30,7 @@ struct Options
     bool useSparseTextures           = true;   ///< whether to use sparse or dense textures
     bool useSmallTextureOptimization = false;  ///< whether to use dense textures for very small textures
     bool useCascadingTextureSizes    = false;  ///< whether to use cascading texture sizes
+    bool coalesceWhiteBlackTiles     = false;  ///< whether to use the same backing store for all white/black tiles
 
     // Memory limits
     size_t maxTexMemPerDevice = 0;  ///< texture to allocate per device (in MB) before starting eviction (0 is unlimited)

--- a/DemandLoading/DemandLoading/include/OptiXToolkit/DemandLoading/Options.h
+++ b/DemandLoading/DemandLoading/include/OptiXToolkit/DemandLoading/Options.h
@@ -31,6 +31,7 @@ struct Options
     bool useSmallTextureOptimization = false;  ///< whether to use dense textures for very small textures
     bool useCascadingTextureSizes    = false;  ///< whether to use cascading texture sizes
     bool coalesceWhiteBlackTiles     = false;  ///< whether to use the same backing store for all white/black tiles
+    bool coalesceDuplicateImages     = false;  ///< whether to coalesce duplicate images
 
     // Memory limits
     size_t maxTexMemPerDevice = 0;  ///< texture to allocate per device (in MB) before starting eviction (0 is unlimited)

--- a/DemandLoading/DemandLoading/src/DemandLoaderImpl.h
+++ b/DemandLoading/DemandLoading/src/DemandLoaderImpl.h
@@ -181,7 +181,8 @@ class DemandLoaderImpl : public DemandLoader
     std::unique_ptr<DemandPageLoaderImpl> m_pageLoader;
 
     std::map<unsigned int, std::unique_ptr<DemandTextureImpl>> m_textures; // demand-loaded textures, indexed by textureId
-    std::map<imageSource::ImageSource*, unsigned int> m_imageToTextureId;  // lookup from image* to textureId
+    std::map<imageSource::ImageSource*, unsigned int> m_imageToTextureId;  // look up textureId from image*
+    std::map<unsigned long long, unsigned int> m_hashToTextureId; // look up textureId from image hash
 
     SamplerRequestHandler m_samplerRequestHandler;  // Handles requests for texture samplers.
     CascadeRequestHandler m_cascadeRequestHandler;  // Handles cascading texture sizes.

--- a/DemandLoading/DemandLoading/src/Memory/DeviceMemoryManager.cpp
+++ b/DemandLoading/DemandLoading/src/Memory/DeviceMemoryManager.cpp
@@ -17,10 +17,13 @@ DeviceMemoryManager::DeviceMemoryManager( std::shared_ptr<Options> options )
     : m_options( options )
     , m_samplerPool( new DeviceAllocator(), new FixedSuballocator( sizeof( TextureSampler ), alignof( TextureSampler ) ), SAMPLER_POOL_ALLOC_SIZE )
     , m_deviceContextMemory( new DeviceAllocator(), nullptr )
+    , m_whiteBlackTiles( static_cast<int>( WB_NONE ), otk::TileBlockHandle{0, 0} )
 {
     if( m_options->useSparseTextures )
+    {
         m_tilePool.reset( new TilePool( new TextureTileAllocator(), new HeapSuballocator(),
                                         TextureTileAllocator::getRecommendedAllocationSize(), m_options->maxTexMemPerDevice ) );
+    }
 }
 
 DeviceMemoryManager::~DeviceMemoryManager()

--- a/DemandLoading/DemandLoading/src/Textures/DemandTextureImpl.cpp
+++ b/DemandLoading/DemandLoading/src/Textures/DemandTextureImpl.cpp
@@ -478,38 +478,4 @@ size_t DemandTextureImpl::getMipTailSize()
     return m_mipTailSize; 
 }
 
-unsigned long long DemandTextureImpl::getHash( CUstream stream )
-{
-    if( !m_isInitialized )
-        init();
-
-    // FIXME: Handle non-host fulfilled image types
-    if( m_image->getFillType() != CU_MEMORYTYPE_HOST )
-        return 0ULL;
-
-    // Start hash as checksum of info
-    const unsigned long long m = 1013904223ULL;
-    unsigned long long hash = m_info.width;
-    hash = hash * m + m_info.height;
-    hash = hash * m + m_info.format;
-    hash = hash * m + m_info.numChannels;
-    hash = hash * m + m_info.numMipLevels;
-
-    // Continue with checksum of a coarse mip level.
-    int mipLevel = static_cast<int>( log2f( (m_info.width + m_info.height) / 64.0f ) );
-    mipLevel = std::max( std::min( mipLevel, (int)m_info.numMipLevels-1 ), 0 );
-
-    unsigned int levelWidth = m_info.width >> mipLevel;
-    unsigned int levelHeight = m_info.height >> mipLevel;
-    unsigned int mipLevelSize = levelWidth * levelHeight * imageSource::getBytesPerChannel( m_info.format ) * m_info.numChannels;
-    std::vector<unsigned long long> buffer( ( mipLevelSize + 7 ) / 8 );
-    buffer.back() = 0;
-    m_image->readMipLevel( (char*)buffer.data(), mipLevel, levelWidth, levelHeight, stream );
-
-    for( unsigned int i=0; i<buffer.size(); ++i )
-        hash = hash * m + buffer[i];
-
-    return hash;
-}
-
 }  // namespace demandLoading

--- a/DemandLoading/DemandLoading/src/Textures/DemandTextureImpl.h
+++ b/DemandLoading/DemandLoading/src/Textures/DemandTextureImpl.h
@@ -200,6 +200,9 @@ class DemandTextureImpl : public DemandTexture
     /// Return a list of all the variant ids
     const std::vector<unsigned int>& getVariantsIds() { return m_variantTextureIds; }
 
+    /// Compute a hash for the texture
+    unsigned long long getHash( CUstream stream );
+
   private:
     // A mutex guards against concurrent initialization, which can arise when the sampler
     // is requested on multiple devices.  Tiles can be filled concurrently, along with the mip tail.

--- a/DemandLoading/DemandLoading/src/Textures/DemandTextureImpl.h
+++ b/DemandLoading/DemandLoading/src/Textures/DemandTextureImpl.h
@@ -200,9 +200,6 @@ class DemandTextureImpl : public DemandTexture
     /// Return a list of all the variant ids
     const std::vector<unsigned int>& getVariantsIds() { return m_variantTextureIds; }
 
-    /// Compute a hash for the texture
-    unsigned long long getHash( CUstream stream );
-
   private:
     // A mutex guards against concurrent initialization, which can arise when the sampler
     // is requested on multiple devices.  Tiles can be filled concurrently, along with the mip tail.

--- a/DemandLoading/DemandLoading/src/WhiteBlackTileCheck.h
+++ b/DemandLoading/DemandLoading/src/WhiteBlackTileCheck.h
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#pragma once
+
+#include <OptiXToolkit/ImageSource/ImageHelpers.h>
+#include <OptiXToolkit/Memory/MemoryBlockDesc.h>
+using namespace otk;
+
+namespace demandLoading
+{
+
+// 0/1 tile types for float4, float2, float, half4, half2, half, uchar4, uchar2, uchar
+enum WhiteBlackTileType { F4_0000=0, F4_0001, F4_1110, F4_1111, F2_00, F2_11, F_0, F_1,
+                          H4_0000, H4_0001, H4_1110, H4_1111, H2_00, H2_11, H_0, H_1,
+                          UB4_0000, UB4_0001, UB4_1110, UB4_1111, UB2_00, UB2_11, UB_0, UB_1,
+                          WB_NONE };
+
+// Check whether a tile has all uniform color
+template<class TYPE> bool tileHasUniformColor( TYPE* tile, TYPE val )
+{
+    // Make a small array to compare against so memcmp is not called so many times.
+    const int testGroupSize = 8;
+    TYPE valBuff[testGroupSize] = {val, val, val, val, val, val, val, val};
+
+    int numTests = TILE_SIZE_IN_BYTES / ( testGroupSize * sizeof( TYPE ) );
+    for( int i = 0; i < numTests; ++i )
+    {
+        if( memcmp( &tile[i*testGroupSize], valBuff, testGroupSize * sizeof( TYPE ) ) )
+            return false;
+    }
+    return true;
+}
+
+/// Check whether a tile is all white or all black for reuse.
+inline WhiteBlackTileType classifyTileAsWhiteOrBlack( char* data, CUarray_format format, int numChannels )
+{
+    // float formats
+    if( format == CU_AD_FORMAT_FLOAT )
+    {
+        if( numChannels == 4 && tileHasUniformColor<float4>( (float4*)data, float4{0,0,0,0} ) )
+            return F4_0000;
+        if( numChannels == 4 && tileHasUniformColor<float4>( (float4*)data, float4{0,0,0,1} ) )
+            return F4_0001;
+        if( numChannels == 4 && tileHasUniformColor<float4>( (float4*)data, float4{1,1,1,0} ) )
+            return F4_1110;
+        if( numChannels == 4 && tileHasUniformColor<float4>( (float4*)data, float4{1,1,1,1} ) )
+            return F4_1111;
+        if( numChannels == 2 && tileHasUniformColor<float2>( (float2*)data, float2{0,0} ) )
+            return F2_00;
+        if( numChannels == 2 && tileHasUniformColor<float2>( (float2*)data, float2{1,1} ) )
+            return F2_11;
+        if( numChannels == 1 && tileHasUniformColor<float>( (float*)data, 0.0f ) )
+            return F_0;
+        if( numChannels == 1 && tileHasUniformColor<float>( (float*)data, 1.0f ) )
+            return F_1;
+        return WB_NONE;
+    }
+
+    // half formats
+    if( format == CU_AD_FORMAT_HALF )
+    {
+        if( numChannels == 4 && tileHasUniformColor<half4>( (half4*)data, half4{0,0,0,0} ) )
+            return H4_0000;
+        if( numChannels == 4 && tileHasUniformColor<half4>( (half4*)data, half4{0,0,0,1} ) )
+            return H4_0001;
+        if( numChannels == 4 && tileHasUniformColor<half4>( (half4*)data, half4{1,1,1,0} ) )
+            return H4_1110;
+        if( numChannels == 4 && tileHasUniformColor<half4>( (half4*)data, half4{1,1,1,1} ) )
+            return H4_1111;
+        if( numChannels == 2 && tileHasUniformColor<half2>( (half2*)data, half2{0,0} ) )
+            return H2_00;
+        if( numChannels == 2 && tileHasUniformColor<half2>( (half2*)data, half2{1,1} ) )
+            return H2_11;
+        if( numChannels == 1 && tileHasUniformColor<half>( (half*)data, (half)0.0f ) )
+            return H_0;
+        if( numChannels == 1 && tileHasUniformColor<half>( (half*)data, (half)1.0f ) )
+            return H_1;
+        return WB_NONE;
+    }
+
+    // uchar formats
+    if( format == CU_AD_FORMAT_UNSIGNED_INT8 )
+    {
+        if( numChannels == 4 && tileHasUniformColor<uchar4>( (uchar4*)data, uchar4{0,0,0,0} ) )
+            return UB4_0000;
+        if( numChannels == 4 && tileHasUniformColor<uchar4>( (uchar4*)data, uchar4{0,0,0,255} ) )
+            return UB4_0001;
+        if( numChannels == 4 && tileHasUniformColor<uchar4>( (uchar4*)data, uchar4{255,255,255,0} ) )
+            return UB4_1110;
+        if( numChannels == 4 && tileHasUniformColor<uchar4>( (uchar4*)data, uchar4{255,255,255,255} ) )
+            return UB4_1111;
+        if( numChannels == 2 && tileHasUniformColor<uchar2>( (uchar2*)data, uchar2{0,0} ) )
+            return UB2_00;
+        if( numChannels == 2 && tileHasUniformColor<uchar2>( (uchar2*)data, uchar2{255,255} ) )
+            return UB2_11;
+        if( numChannels == 1 && tileHasUniformColor<uchar>( (uchar*)data, 0 ) )
+            return UB_0;
+        if( numChannels == 1 && tileHasUniformColor<uchar>( (uchar*)data, 255 ) )
+            return UB_1;
+        return WB_NONE;
+    }
+
+    return WB_NONE;
+}
+
+}  // namespace demandLoading

--- a/DemandLoading/DemandLoading/tests/CMakeLists.txt
+++ b/DemandLoading/DemandLoading/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ otk_add_executable( testDemandLoading
   TestTextureInstantiation.cpp
   TestTicket.cpp
   TestTileIndexing.cpp
+  TestWhiteBlackTileCheck.cpp
   SourceDir.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/include/SourceDir.h
   )

--- a/DemandLoading/DemandLoading/tests/TestWhiteBlackTileCheck.cpp
+++ b/DemandLoading/DemandLoading/tests/TestWhiteBlackTileCheck.cpp
@@ -1,0 +1,107 @@
+//
+// Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+
+#include <cuda.h>
+#include <vector>
+
+#include "WhiteBlackTileCheck.h"
+
+#include <gtest/gtest.h>
+
+using namespace demandLoading;
+using namespace imageSource;
+using namespace otk;
+
+class TestWhiteBlackTileCheck : public testing::Test
+{
+};
+
+TEST_F( TestWhiteBlackTileCheck, FloatTiles )
+{
+    std::vector<float> ftile( TILE_SIZE_IN_BYTES / sizeof(float), 1.0f );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ftile.data(), CU_AD_FORMAT_FLOAT, 1 ), F_1 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ftile.data(), CU_AD_FORMAT_FLOAT, 2 ), F2_11 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ftile.data(), CU_AD_FORMAT_FLOAT, 4 ), F4_1111 );
+
+    std::fill( ftile.begin(), ftile.end(), 0.0f );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ftile.data(), CU_AD_FORMAT_FLOAT, 1 ), F_0 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ftile.data(), CU_AD_FORMAT_FLOAT, 2 ), F2_00 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ftile.data(), CU_AD_FORMAT_FLOAT, 4 ), F4_0000 );
+
+    ftile[0] = 0.5f;
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ftile.data(), CU_AD_FORMAT_FLOAT, 1 ), WB_NONE );
+
+    std::vector<float4> f4tile( TILE_SIZE_IN_BYTES / sizeof(float4), float4{1.0f, 1.0f, 1.0f, 0.0f} );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)f4tile.data(), CU_AD_FORMAT_FLOAT, 4 ), F4_1110 );
+}
+
+TEST_F( TestWhiteBlackTileCheck, HalfTiles )
+{
+    std::vector<half> htile( TILE_SIZE_IN_BYTES / sizeof(half), (half)1.0f );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)htile.data(), CU_AD_FORMAT_HALF, 1 ), H_1 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)htile.data(), CU_AD_FORMAT_HALF, 2 ), H2_11 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)htile.data(), CU_AD_FORMAT_HALF, 4 ), H4_1111 );
+
+    std::fill( htile.begin(), htile.end(), (half)0.0f );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)htile.data(), CU_AD_FORMAT_HALF, 1 ), H_0 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)htile.data(), CU_AD_FORMAT_HALF, 2 ), H2_00 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)htile.data(), CU_AD_FORMAT_HALF, 4 ), H4_0000 );
+
+    htile[25] = (half)0.5f;
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)htile.data(), CU_AD_FORMAT_HALF, 1 ), WB_NONE );
+
+    std::vector<half4> h4tile( TILE_SIZE_IN_BYTES / sizeof(half4), half4{1.0f, 1.0f, 1.0f, 0.0f} );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)h4tile.data(), CU_AD_FORMAT_HALF, 4 ), H4_1110 );
+}
+
+TEST_F( TestWhiteBlackTileCheck, UcharTiles )
+{
+    std::vector<uchar> ubtile( TILE_SIZE_IN_BYTES / sizeof(uchar), 255 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ubtile.data(), CU_AD_FORMAT_UNSIGNED_INT8, 1 ), UB_1 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ubtile.data(), CU_AD_FORMAT_UNSIGNED_INT8, 2 ), UB2_11 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ubtile.data(), CU_AD_FORMAT_UNSIGNED_INT8, 4 ), UB4_1111 );
+
+    std::fill( ubtile.begin(), ubtile.end(), 0 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ubtile.data(), CU_AD_FORMAT_UNSIGNED_INT8, 1 ), UB_0 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ubtile.data(), CU_AD_FORMAT_UNSIGNED_INT8, 2 ), UB2_00 );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ubtile.data(), CU_AD_FORMAT_UNSIGNED_INT8, 4 ), UB4_0000 );
+
+    ubtile[25] = 10;
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ubtile.data(), CU_AD_FORMAT_UNSIGNED_INT8, 1 ), WB_NONE );
+
+    std::vector<uchar4> ub4tile( TILE_SIZE_IN_BYTES / sizeof(uchar4), uchar4{0,0,0,255} );
+    EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)ub4tile.data(), CU_AD_FORMAT_UNSIGNED_INT8, 4 ), UB4_0001 );
+}
+
+TEST_F( TestWhiteBlackTileCheck, SpeedTest )
+{
+    std::vector<float> tile( TILE_SIZE_IN_BYTES / sizeof(float), 1.0f );
+    for( int i=0; i<1000; ++i )
+        EXPECT_EQ( classifyTileAsWhiteOrBlack( (char*)tile.data(), CU_AD_FORMAT_FLOAT, 1 ), F_1 );
+}

--- a/DemandLoading/ImageSource/include/OptiXToolkit/ImageSource/ImageSource.h
+++ b/DemandLoading/ImageSource/include/OptiXToolkit/ImageSource/ImageSource.h
@@ -106,7 +106,11 @@ class ImageSource
     /// be zero if the reader does not load tiles from disk, e.g. for procedural textures.
     virtual double getTotalReadTime() const = 0;
 
+    /// Return true if the image has a cascade (larger size) that could be switched to.
     virtual bool hasCascade() const = 0;
+
+    /// Return a hash of the image, using a small mip level.
+    unsigned long long getHash( CUstream stream );
 };
 
 /// Base class for ImageSource with default implementation of readMipTail, etc.

--- a/Memory/include/OptiXToolkit/Memory/MemoryBlockDesc.h
+++ b/Memory/include/OptiXToolkit/Memory/MemoryBlockDesc.h
@@ -76,6 +76,7 @@ union TileBlockDesc
     bool         isGood() { return numTiles != 0; }
     bool         isBad() { return numTiles == 0; }
     unsigned int offset() { return tileId * TILE_SIZE_IN_BYTES; }
+    bool operator ==(TileBlockDesc& desc) { return data == desc.data; }
 };
 
 /// Bundle a TileBlockDesc with its handle
@@ -83,6 +84,8 @@ struct TileBlockHandle
 {
     CUmemGenericAllocationHandle handle;
     TileBlockDesc                block;
+
+    bool operator ==(TileBlockHandle& bh) { return ( handle == bh.handle ) && ( block == bh.block ); }
 };
 
 }  // namespace otk

--- a/Memory/tests/TestBinnedSuballocator.cpp
+++ b/Memory/tests/TestBinnedSuballocator.cpp
@@ -85,3 +85,23 @@ TEST_F( TestBinnedSuballocator, allocFree )
     }
     EXPECT_EQ( suballocator.freeSpace(), numAllocations * 128 );
 }
+
+TEST_F( TestBinnedSuballocator, untrack )
+{
+    std::vector<uint64_t> sizes( {2, 4, 8, 16, 32} );
+    std::vector<uint64_t> chunkItems( {128, 128, 128, 128, 128} );
+    BinnedSuballocatorT   suballocator( sizes, chunkItems );
+    suballocator.track( 0, 1024 );
+    suballocator.track( 2048, 1024 );
+
+    EXPECT_EQ( suballocator.trackedSize(), 2048ULL );
+    EXPECT_EQ( suballocator.freeSpace(), 2048ULL );
+
+    suballocator.alloc( 2, 1 );
+    suballocator.alloc( 8, 1 );
+
+    EXPECT_EQ( suballocator.freeSpace(), 2038ULL );
+
+    suballocator.untrack( 2048, 1024 );
+    EXPECT_EQ( suballocator.trackedSize(), 1024ULL );
+}

--- a/Memory/tests/TestFixedSuballocator.cpp
+++ b/Memory/tests/TestFixedSuballocator.cpp
@@ -71,3 +71,13 @@ TEST_F( TestFixedSuballocator, allocFree )
     }
     EXPECT_TRUE( suballocator.freeSpace() == suballocator.trackedSize() );
 }
+
+TEST_F( TestFixedSuballocator, untrack )
+{
+    FixedSuballocator suballocator( 64, 64 );
+    suballocator.track( 0, 1024 );
+    suballocator.track( 2048, 1024 );
+
+    suballocator.untrack( 2048, 1024 );
+    EXPECT_EQ( suballocator.trackedSize(), 1024ULL );
+}

--- a/Memory/tests/TestHeapSuballocator.cpp
+++ b/Memory/tests/TestHeapSuballocator.cpp
@@ -58,7 +58,7 @@ TEST_F( TestHeapSuballocator, allocMany )
 
 TEST_F( TestHeapSuballocator, allocFree )
 {
-    const uint64_t               numAllocations = 1 << 20;
+    const uint64_t               numAllocations = 1 << 18;
     std::vector<MemoryBlockDesc> allocs;
     heapSuballocator.track( 0, numAllocations );
 
@@ -82,4 +82,13 @@ TEST_F( TestHeapSuballocator, allocFree )
         maxMapSize = std::max( beginMap.size(), maxMapSize );
     }
     EXPECT_TRUE( heapSuballocator.freeSpace() == heapSuballocator.trackedSize() );
+}
+
+TEST_F( TestHeapSuballocator, untrack )
+{
+    heapSuballocator.track( 0, 1024 );
+    heapSuballocator.track( 2048, 1024 );
+
+    heapSuballocator.untrack( 0, 1024 );
+    EXPECT_EQ( heapSuballocator.trackedSize(), 1024ULL );
 }

--- a/Memory/tests/TestRingSuballocator.cpp
+++ b/Memory/tests/TestRingSuballocator.cpp
@@ -74,3 +74,20 @@ TEST_F( TestRingSuballocator, freeAll )
         EXPECT_TRUE( block.isGood() );
     }
 }
+
+TEST_F( TestRingSuballocator, untrack )
+{
+    ringSuballocator.track( 0, 1024 );
+    ringSuballocator.track( 2048, 1024 );
+    ringSuballocator.track( 4096, 1024 );
+    EXPECT_EQ( static_cast<uint64_t>( 3 * 1024 ), ringSuballocator.freeSpace() );
+
+    ringSuballocator.untrack( 2048, 1024 );
+    EXPECT_EQ( static_cast<uint64_t>( 2 * 1024 ), ringSuballocator.freeSpace() );
+    EXPECT_EQ( static_cast<uint64_t>( 2 * 1024 ), ringSuballocator.trackedSize() );
+
+    ringSuballocator.untrack( 0, 1024 );
+    ringSuballocator.untrack( 4096, 1024 );
+    EXPECT_EQ( 0ULL, ringSuballocator.freeSpace() );
+    EXPECT_EQ( 0ULL, ringSuballocator.trackedSize() );
+}

--- a/examples/DemandLoading/DemandTextureAppBase/src/DemandTextureApp.cpp
+++ b/examples/DemandLoading/DemandTextureAppBase/src/DemandTextureApp.cpp
@@ -391,7 +391,7 @@ void DemandTextureApp::initDemandLoading()
     options.maxTexMemPerDevice  = maxTexMem;         // max texture to use before starting eviction (0 is unlimited)
     options.maxPinnedMemory     = 64 * 1024 * 1024;  // max pinned memory to reserve for transfers.
     options.maxThreads          = 0;                 // request threads. (0 is std::thread::hardware_concurrency)
-    options.evictionActive      = true;             // turn on or off eviction
+    options.evictionActive      = true;              // turn on or off eviction
     options.useSparseTextures   = m_useSparseTextures;  // use sparse or dense textures
     options.useCascadingTextureSizes = m_useCascadingTextureSizes; // whether to use cascading texture sizes
 


### PR DESCRIPTION
Coalesce identical textures, using a hashing scheme to detect them.  
Coalesce white and black texture tiles, by checking tiles before they are bound. 