### PR TITLE
Fixed build errors arising with gcc-13.2.

### DIFF
--- a/DemandLoading/ImageSource/tests/MockImageSource.h
+++ b/DemandLoading/ImageSource/tests/MockImageSource.h
@@ -16,49 +16,6 @@
     case enum_:                                                                                                        \
         return str << #enum_ << " (" << static_cast<int>( enum_ ) << ')'
 
-inline std::ostream& operator<<( std::ostream& str, CUarray_format val )
-{
-    switch( val )
-    {
-        OUTPUT_ENUM( CU_AD_FORMAT_UNSIGNED_INT8 );
-        OUTPUT_ENUM( CU_AD_FORMAT_UNSIGNED_INT16 );
-        OUTPUT_ENUM( CU_AD_FORMAT_UNSIGNED_INT32 );
-        OUTPUT_ENUM( CU_AD_FORMAT_SIGNED_INT8 );
-        OUTPUT_ENUM( CU_AD_FORMAT_SIGNED_INT16 );
-        OUTPUT_ENUM( CU_AD_FORMAT_SIGNED_INT32 );
-        OUTPUT_ENUM( CU_AD_FORMAT_HALF );
-        OUTPUT_ENUM( CU_AD_FORMAT_FLOAT );
-        OUTPUT_ENUM( CU_AD_FORMAT_NV12 );
-        OUTPUT_ENUM( CU_AD_FORMAT_UNORM_INT8X1 );
-        OUTPUT_ENUM( CU_AD_FORMAT_UNORM_INT8X2 );
-        OUTPUT_ENUM( CU_AD_FORMAT_UNORM_INT8X4 );
-        OUTPUT_ENUM( CU_AD_FORMAT_UNORM_INT16X1 );
-        OUTPUT_ENUM( CU_AD_FORMAT_UNORM_INT16X2 );
-        OUTPUT_ENUM( CU_AD_FORMAT_UNORM_INT16X4 );
-        OUTPUT_ENUM( CU_AD_FORMAT_SNORM_INT8X1 );
-        OUTPUT_ENUM( CU_AD_FORMAT_SNORM_INT8X2 );
-        OUTPUT_ENUM( CU_AD_FORMAT_SNORM_INT8X4 );
-        OUTPUT_ENUM( CU_AD_FORMAT_SNORM_INT16X1 );
-        OUTPUT_ENUM( CU_AD_FORMAT_SNORM_INT16X2 );
-        OUTPUT_ENUM( CU_AD_FORMAT_SNORM_INT16X4 );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC1_UNORM );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC1_UNORM_SRGB );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC2_UNORM );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC2_UNORM_SRGB );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC3_UNORM );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC3_UNORM_SRGB );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC4_UNORM );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC4_SNORM );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC5_UNORM );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC5_SNORM );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC6H_UF16 );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC6H_SF16 );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC7_UNORM );
-        OUTPUT_ENUM( CU_AD_FORMAT_BC7_UNORM_SRGB );
-    }
-    return str << "? (" << static_cast<int>( val ) << ')';
-}
-
 inline std::ostream& operator<<( std::ostream& str, CUmemorytype val )
 {
     switch( val )

--- a/Memory/tests/TestHeapSuballocator.cpp
+++ b/Memory/tests/TestHeapSuballocator.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <map>
+#include <random>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -71,7 +72,9 @@ TEST_F( TestHeapSuballocator, allocFree )
     }
     EXPECT_TRUE( heapSuballocator.freeSpace() == 0 );
 
-    std::random_shuffle( allocs.begin(), allocs.end() );  // worst case
+    std::random_device rng;
+    std::mt19937       urng( rng() );
+    std::shuffle( allocs.begin(), allocs.end(), urng );  // worst case
     //std::reverse( allocs.begin(), allocs.end() ); // best case
 
     const std::map<uint64_t, uint64_t>& beginMap = heapSuballocator.getBeginMap();

--- a/ShaderUtil/include/OptiXToolkit/ShaderUtil/CubicFiltering.h
+++ b/ShaderUtil/include/OptiXToolkit/ShaderUtil/CubicFiltering.h
@@ -190,7 +190,7 @@ textureCubic( CUtexObject texture, int texWidth, int texHeight,
 
     // Return unless we have to blend between levels
     if( filterMode != FILTER_BICUBIC || ml == mipLevel || ml < 0.0f )
-        return;
+        return true;
 
     //-------------------------------------------------------------------------------
     // Sample second level for blending between levels in FILTER_BICUBIC mode
@@ -234,4 +234,5 @@ textureCubic( CUtexObject texture, int texWidth, int texHeight,
         if( dresultdt )
             *dresultdt = levelBlend * ( drds * cosf( b ) + drdt * sinf( b ) ) + (1.0f - levelBlend) * *dresultdt;
     }
+    return true;
 }

--- a/examples/Util/src/ImageBuffer.cpp
+++ b/examples/Util/src/ImageBuffer.cpp
@@ -7,6 +7,8 @@
 #include <stb_image_write.h>
 
 #include <cmath>
+
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>


### PR DESCRIPTION
Eliminated operator<<( CUarray_format ) in MockImageSource.h, which was unused.