### PR TITLE
make setMaxTextureMemory deallocate memory if the max texture memory is reduced. 

### DIFF
--- a/DemandLoading/DemandLoading/src/DemandLoaderImpl.cpp
+++ b/DemandLoading/DemandLoading/src/DemandLoaderImpl.cpp
@@ -586,6 +586,7 @@ MemoryPool<PinnedAllocator, RingSuballocator>* DemandLoaderImpl::getPinnedMemory
 
 void DemandLoaderImpl::setMaxTextureMemory( size_t maxMem )
 {
+    std::unique_lock<std::mutex> lock( m_mutex );
     m_pageLoader->setMaxTextureMemory( maxMem );
 }
 

--- a/DemandLoading/DemandLoading/src/Memory/DeviceMemoryManager.cpp
+++ b/DemandLoading/DemandLoading/src/Memory/DeviceMemoryManager.cpp
@@ -69,4 +69,20 @@ void DeviceMemoryManager::freeDeviceContext( DeviceContext* context )
     m_deviceContextFreeList.push_back( m_deviceContextPool[context->poolIndex] );
 }
 
+void DeviceMemoryManager::setMaxTextureTileMemory( size_t maxMemory )
+{
+    if( !m_tilePool )
+        return;
+
+    m_tilePool->setMaxSize( static_cast<uint64_t>( maxMemory ), true, CUstream{0} );
+
+    // Remove references to white/black tiles that were deleted
+    unsigned int numArenas = m_tilePool->numAllocations();
+    for( otk::TileBlockHandle &bh : m_whiteBlackTiles )
+    {
+        if( bh.handle != 0 && bh.block.arenaId >= numArenas )
+            bh = otk::TileBlockHandle{0,0};
+    }
+}
+
 }  // namespace demandLoading

--- a/DemandLoading/DemandLoading/src/Memory/DeviceMemoryManager.h
+++ b/DemandLoading/DemandLoading/src/Memory/DeviceMemoryManager.h
@@ -102,7 +102,7 @@ class DeviceMemoryManager
     void setMaxTextureTileMemory( size_t maxMemory )
     {
         if( m_tilePool )
-            m_tilePool->setMaxSize( static_cast<uint64_t>( maxMemory ) );
+            m_tilePool->setMaxSize( static_cast<uint64_t>( maxMemory ), true, CUstream{0} );
     }
 
     /// Return the amount of device memory allocated in different pools.

--- a/DemandLoading/DemandLoading/src/Memory/DeviceMemoryManager.h
+++ b/DemandLoading/DemandLoading/src/Memory/DeviceMemoryManager.h
@@ -99,11 +99,7 @@ class DeviceMemoryManager
     size_t getTilePoolArenaSize() const { return m_tilePool ? static_cast<size_t>( m_tilePool->allocationGranularity() ) : 2 * 1024 * 1024; }
 
     /// Set the max texture memory
-    void setMaxTextureTileMemory( size_t maxMemory )
-    {
-        if( m_tilePool )
-            m_tilePool->setMaxSize( static_cast<uint64_t>( maxMemory ), true, CUstream{0} );
-    }
+    void setMaxTextureTileMemory( size_t maxMemory );
 
     /// Return the amount of device memory allocated in different pools.
     size_t getSamplerMemory() const { return m_samplerPool.trackedSize(); }

--- a/DemandLoading/DemandLoading/src/Textures/TextureRequestHandler.cpp
+++ b/DemandLoading/DemandLoading/src/Textures/TextureRequestHandler.cpp
@@ -82,7 +82,7 @@ void TextureRequestHandler::fillTileRequest( CUstream stream, unsigned int pageI
         bh = deviceMemoryManager->allocateTileBlock( TILE_SIZE_IN_BYTES );
         if( bh.block.isBad() )
         {
-            // If the allocation failed, set max memory to current size and turn on eviction.
+            // If the allocation failed, set max memory to current size to prevent repeat requests.
             m_loader->setMaxTextureMemory( deviceMemoryManager->getTextureTileMemory() );
             return;
         }

--- a/Memory/include/OptiXToolkit/Memory/MemoryPool.h
+++ b/Memory/include/OptiXToolkit/Memory/MemoryPool.h
@@ -312,6 +312,9 @@ class MemoryPool
     /// Return the maximum memory that the pool will allocate
     uint64_t maxSize() const { return m_maxSize; }
 
+    /// Return the number of allocations that the pool is tracking
+    uint64_t numAllocations() const { return static_cast<unsigned int>( m_allocations.size() ); }
+
     /// Return the size of chunks that the allocator will allocate.
     /// Also indicates that largest block that the pool can allocate.
     uint64_t allocationGranularity() const { return m_allocationGranularity; }

--- a/ShaderUtil/include/OptiXToolkit/ShaderUtil/CubicFiltering.h
+++ b/ShaderUtil/include/OptiXToolkit/ShaderUtil/CubicFiltering.h
@@ -93,7 +93,7 @@ textureWeighted( CUtexObject texture, float i, float j, float4 wx, float4 wy, in
 }
 
 /// Compute cubic filtered texture sample based on filterMode.
-template <class TYPE> D_INLINE bool
+template <class TYPE> D_INLINE void
 textureCubic( CUtexObject texture, int texWidth, int texHeight,
               unsigned int filterMode, unsigned int mipmapFilterMode, unsigned int maxAnisotropy,
               float s, float t, float2 ddx, float2 ddy, TYPE* result, TYPE* dresultds, TYPE* dresultdt )
@@ -150,7 +150,7 @@ textureCubic( CUtexObject texture, int texWidth, int texHeight,
         }
 
         if( cubicBlend <= 0.0f )
-            return true;
+            return;
     }
 
     // Get unnormalized texture coordinates
@@ -190,7 +190,7 @@ textureCubic( CUtexObject texture, int texWidth, int texHeight,
 
     // Return unless we have to blend between levels
     if( filterMode != FILTER_BICUBIC || ml == mipLevel || ml < 0.0f )
-        return true;
+        return;
 
     //-------------------------------------------------------------------------------
     // Sample second level for blending between levels in FILTER_BICUBIC mode
@@ -234,5 +234,4 @@ textureCubic( CUtexObject texture, int texWidth, int texHeight,
         if( dresultdt )
             *dresultdt = levelBlend * ( drds * cosf( b ) + drdt * sinf( b ) ) + (1.0f - levelBlend) * *dresultdt;
     }
-    return true;
 }


### PR DESCRIPTION
demandLoader::setMaxTextureMemory previously would not reduce the amount of allocated memory, only expand it.  This change allows texture tile memory to be released back to the operating system.