### PR TITLE
Try using an OBJECT library to resolve pbrt circular dependency

### DIFF
--- a/examples/pbrtParser/CMakeLists.txt
+++ b/examples/pbrtParser/CMakeLists.txt
@@ -44,7 +44,11 @@ string(TIMESTAMP t2 "%s")
 math(EXPR elapsed "${t2} - ${t1}")
 message(VERBOSE "FetchContent(pbrt) took ${elapsed} seconds.")
 
-add_library( pbrtParser STATIC
+# Use an OBJECT library to avoid circular dependency between the pbrt code
+# that wants to call Error and Warning, but we want to provide the implementation
+# of those functions in pbrtApi so that they can delegate warnings and errors
+# to the interface.
+add_library( pbrtParser OBJECT
   ${pbrt_api_dir}/api.h
   ${pbrt_api_dir}/error.h
   ${pbrt_api_dir}/fileutil.cpp


### PR DESCRIPTION
If this doesn't work on linux, we'll just have to revert the change that separated these libraries.  Why can't we have nice things? :)