### PR TITLE
Extract common mechanisms

### DIFF
--- a/CMake/SetCxxStandard.cmake
+++ b/CMake/SetCxxStandard.cmake
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+function(set_cxx_standard version)
+    set(CMAKE_CXX_STANDARD ${version} PARENT_SCOPE)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON PARENT_SCOPE)
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,14 +18,14 @@ cmake_minimum_required( VERSION 3.27 FATAL_ERROR )
 include( BuildConfig )
 include( Policies )
 include( ProjectOptions )
+include( SetCxxStandard )
 
 #########################################################
 # Set the project name (i.e. the VS solution file).
 project( ${OTK_PROJECT_NAME} LANGUAGES C CXX CUDA VERSION 0.9.1 )
 set( OTK_PROJECT_SOURCE_DIR ${${OTK_PROJECT_NAME}_SOURCE_DIR} )
 set( OTK_PROJECT_BINARY_DIR ${${OTK_PROJECT_NAME}_BINARY_DIR} )
-set( CMAKE_CXX_STANDARD 11 )
-set( CMAKE_CXX_STANDARD_REQUIRED TRUE )
+set_cxx_standard( 11 )
 set( CMAKE_CXX_EXTENSIONS OFF )
 
 #########################################################

--- a/DemandLoading/CMakeLists.txt
+++ b/DemandLoading/CMakeLists.txt
@@ -5,12 +5,11 @@
 # Using the latest CMake is highly recommended, to ensure up-to-date CUDA language support.
 cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 include(Policies)
+include(SetCxxStandard)
 
 project(DemandLoading LANGUAGES C CXX CUDA)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set_cxx_standard(11)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
 include(GNUInstallDirs)
 include(BuildConfig)
 include(CTest)

--- a/DemandLoading/DemandLoading/CMakeLists.txt
+++ b/DemandLoading/DemandLoading/CMakeLists.txt
@@ -5,10 +5,10 @@
 # Using the latest CMake is highly recommended, to ensure up-to-date CUDA language support.
 cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 include(Policies)
+include(SetCxxStandard)
 
 project(DemandLoading LANGUAGES C CXX CUDA)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set_cxx_standard(11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(GNUInstallDirs)

--- a/DemandLoading/DemandLoading/tests/CMakeLists.txt
+++ b/DemandLoading/DemandLoading/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ configure_file( SourceDir.h.in include/SourceDir.h @ONLY )
 target_link_libraries( testDemandLoading
   testDemandLoadingKernels
   DemandLoadingKernels
+  OptiXToolkit::OptiXMemory
   OptiX::OptiX
   DemandLoading
   ShaderUtil
@@ -127,6 +128,7 @@ target_include_directories( testTextureFootprint PUBLIC
 target_link_libraries( testTextureFootprint
   testTextureFootprintKernel
   DemandLoading
+  OptiXToolkit::OptiXMemory
   CUDA::cudart
   GTest::gtest_main
   ${CMAKE_DL_LIBS}

--- a/DemandLoading/DemandLoading/tests/DeferredImageLoading.cpp
+++ b/DemandLoading/DemandLoading/tests/DeferredImageLoading.cpp
@@ -12,6 +12,7 @@
 #include <OptiXToolkit/Error/optixErrorCheck.h>
 #include <OptiXToolkit/ImageSource/ImageSource.h>
 #include <OptiXToolkit/ImageSource/TextureInfo.h>
+#include <OptiXToolkit/OptiXMemory/CompileOptions.h>
 
 #include <optix.h>
 #include <optix_function_table_definition.h>
@@ -204,20 +205,7 @@ void DeferredImageLoadingTest::createModules()
 {
     OptixModuleCompileOptions compileOptions{};
     compileOptions.maxRegisterCount = OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT;
-#ifdef NDEBUG
-    bool debugInfo{ false };
-#else
-    bool debugInfo{ true };
-#endif
-    compileOptions.optLevel   = debugInfo ? OPTIX_COMPILE_OPTIMIZATION_LEVEL_0 :
-                                            OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
-#if OPTIX_VERSION >= 70400
-    compileOptions.debugLevel = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL :
-                                            OPTIX_COMPILE_DEBUG_LEVEL_MINIMAL;
-#else
-    compileOptions.debugLevel = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL :
-                                            OPTIX_COMPILE_DEBUG_LEVEL_LINEINFO;
-#endif
+    otk::configModuleCompileOptions( compileOptions );
     OTK_ERROR_CHECK_LOG( optixModuleCreate( m_context, &compileOptions, &m_pipelineOpts, DeferredImageLoadingKernelsCudaText(),
                                              DeferredImageLoadingKernelsCudaSize, LOG, &LOG_SIZE, &m_module ) );
 }

--- a/DemandLoading/DemandLoading/tests/TestTextureFootprint.cpp
+++ b/DemandLoading/DemandLoading/tests/TestTextureFootprint.cpp
@@ -12,6 +12,7 @@
 #include <OptiXToolkit/Error/cuErrorCheck.h>
 #include <OptiXToolkit/Error/cudaErrorCheck.h>
 #include <OptiXToolkit/Error/optixErrorCheck.h>
+#include <OptiXToolkit/OptiXMemory/CompileOptions.h>
 
 #include <optix.h>
 #include <optix_function_table_definition.h>
@@ -289,20 +290,7 @@ class TextureFootprintFixture
             OptixPipelineCompileOptions pipeline_compile_options = {};
             {
                 OptixModuleCompileOptions module_compile_options = {};
-#ifdef NDEBUG
-                bool debugInfo{ false };
-#else
-                bool debugInfo{ true };
-#endif
-                module_compile_options.optLevel         = debugInfo ? OPTIX_COMPILE_OPTIMIZATION_LEVEL_0 :
-                                                                      OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
-#if OPTIX_VERSION >= 70400
-                module_compile_options.debugLevel       = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL :
-                                                                      OPTIX_COMPILE_DEBUG_LEVEL_MINIMAL;
-#else
-                module_compile_options.debugLevel       = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL :
-                                                                      OPTIX_COMPILE_DEBUG_LEVEL_LINEINFO;
-#endif
+                otk::configModuleCompileOptions( module_compile_options );
                 module_compile_options.maxRegisterCount = OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT;
 
                 pipeline_compile_options.usesMotionBlur        = false;

--- a/Memory/CMakeLists.txt
+++ b/Memory/CMakeLists.txt
@@ -5,10 +5,11 @@
 # Using the latest CMake is highly recommended, to ensure up-to-date CUDA language support.
 cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 include(Policies)
+include(SetCxxStandard)
 
 project(Memory LANGUAGES C CXX CUDA)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+
+set_cxx_standard(11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(BuildConfig)

--- a/Memory/CMakeLists.txt
+++ b/Memory/CMakeLists.txt
@@ -129,6 +129,7 @@ target_sources(OptiXMemory
   BASE_DIRS include
   FILES
   include/OptiXToolkit/OptiXMemory/Builders.h
+  include/OptiXToolkit/OptiXMemory/CompileOptions.h
   include/OptiXToolkit/OptiXMemory/Record.h
   include/OptiXToolkit/OptiXMemory/SyncRecord.h
 )

--- a/Memory/include/OptiXToolkit/OptiXMemory/CompileOptions.h
+++ b/Memory/include/OptiXToolkit/OptiXMemory/CompileOptions.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <optix.h>
+
+namespace otk {
+
+/// \brief Configures the OptiX module compile options based on the build type.
+inline void configModuleCompileOptions( OptixModuleCompileOptions& options )
+{
+#ifndef NDEBUG
+    options.optLevel = OPTIX_COMPILE_OPTIMIZATION_LEVEL_0;
+#if OPTIX_VERSION >= 70400
+    options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
+#endif
+
+#else
+    options.optLevel = OPTIX_COMPILE_OPTIMIZATION_LEVEL_3;
+#if OPTIX_VERSION >= 70400
+    options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_NONE;
+#endif
+
+#endif
+}
+
+/// \brief Configures the OptiX pipeline link options based on the build type.
+inline void configPipelineLinkOptions( OptixPipelineLinkOptions& options )
+{
+#if OPTIX_VERSION < 70700
+#ifdef NDEBUG
+    options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_NONE;
+#else
+    options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
+#endif
+#endif
+}
+
+}  // namespace otk

--- a/OmmBaking/CMakeLists.txt
+++ b/OmmBaking/CMakeLists.txt
@@ -5,10 +5,10 @@
 # Using the latest CMake is highly recommended, to ensure up-to-date CUDA language support.
 cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 include(Policies)
+include(SetCxxStandard)
 
 project(CuOmmBaking LANGUAGES C CXX CUDA)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set_cxx_standard(17) # CUB requires C++17
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(GNUInstallDirs)

--- a/OmmBaking/tests/CMakeLists.txt
+++ b/OmmBaking/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ target_link_libraries( testCuOmmBaking
   CuOmmBaking
   OptiX::OptiX
   OptiXToolkit::Error
+  OptiXToolkit::OptiXMemory
   tinyddsloader
   tinyexr
   tinygltf

--- a/OmmBaking/tests/Util/OptiXScene.cpp
+++ b/OmmBaking/tests/Util/OptiXScene.cpp
@@ -17,6 +17,8 @@
 #include <iostream>
 #include <unordered_map>
 
+#include <OptiXToolkit/OptiXMemory/CompileOptions.h>
+
 #include "OptiXScene.h"
 
 #if OPTIX_VERSION < 70700
@@ -443,21 +445,8 @@ OptixResult OptixOmmScene::buildPipeline( const char* optixirInput, const size_t
     OptixTraversableGraphFlags traversableGraphFlags = OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_LEVEL_INSTANCING;
 
     // Compile modules
-    OptixModuleCompileOptions moduleCompileOptions = {};
-#ifdef NDEBUG
-    bool debugInfo{ false };
-#else
-    bool debugInfo{ true };
-#endif
-    moduleCompileOptions.optLevel   = debugInfo ? OPTIX_COMPILE_OPTIMIZATION_LEVEL_0 :
-                                                    OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
-#if OPTIX_VERSION >= 70400
-    moduleCompileOptions.debugLevel = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL :
-                                                    OPTIX_COMPILE_DEBUG_LEVEL_MINIMAL;
-#else
-    moduleCompileOptions.debugLevel = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL :
-                                                    OPTIX_COMPILE_DEBUG_LEVEL_LINEINFO;
-#endif
+    OptixModuleCompileOptions moduleCompileOptions{};
+    otk::configModuleCompileOptions( moduleCompileOptions );
     moduleCompileOptions.maxRegisterCount = OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT;
 
     OptixPipelineCompileOptions pipelineCompileOptions      = {};

--- a/ShaderUtil/CMakeLists.txt
+++ b/ShaderUtil/CMakeLists.txt
@@ -5,10 +5,10 @@
 # Using the latest CMake is highly recommended, to ensure up-to-date CUDA language support.
 cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 include(Policies)
+include(SetCxxStandard)
 
 project(ShaderUtil LANGUAGES C CXX CUDA)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set_cxx_standard(11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(BuildConfig)

--- a/ShaderUtil/tests/CMakeLists.txt
+++ b/ShaderUtil/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ embed_cuda(
   OUTPUT_TARGET
     TestShaderUtilsKernels
   LIBRARIES
+    OptiXToolkit::OptiXMemory
     OptiXToolkit::ShaderUtil
     OptiX::OptiX
   SOURCES

--- a/ShaderUtil/tests/TestDebugLocation.cpp
+++ b/ShaderUtil/tests/TestDebugLocation.cpp
@@ -13,6 +13,7 @@
 #include <OptiXToolkit/Memory/DeviceBuffer.h>
 #include <OptiXToolkit/Memory/SyncVector.h>
 #include <OptiXToolkit/OptiXMemory/Builders.h>
+#include <OptiXToolkit/OptiXMemory/CompileOptions.h>
 #include <OptiXToolkit/OptiXMemory/SyncRecord.h>
 #include <OptiXToolkit/ShaderUtil/vec_math.h>
 #include <OptiXToolkit/ShaderUtil/vec_printers.h>
@@ -284,6 +285,7 @@ void TestDebugLocation::SetUp()
     contextOptions.validationMode = OPTIX_DEVICE_CONTEXT_VALIDATION_MODE_ALL;
     setLogger( contextOptions, &log );
     context                                                 = Context( nullptr, &contextOptions );
+    otk::configModuleCompileOptions( moduleCompileOptions );
     pipelineCompileOptions.pipelineLaunchParamsVariableName = "g_params";
     module = Module( context, &moduleCompileOptions, &pipelineCompileOptions, TestDebugLocationCudaText(), TestDebugLocationCudaSize );
     otk::ProgramGroupDescBuilder( descs, module )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,10 +16,10 @@ list(APPEND CMAKE_MODULE_PATH
 # Using the latest CMake is highly recommended, to ensure up-to-date CUDA language support.
 cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 include(Policies)
+include(SetCxxStandard)
 
 project(OptiXToolkitExamples LANGUAGES C CXX CUDA)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set_cxx_standard(11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(NOT TARGET OptiX::OptiX)

--- a/examples/CuOmmBaking/Simple/CMakeLists.txt
+++ b/examples/CuOmmBaking/Simple/CMakeLists.txt
@@ -4,6 +4,9 @@
 
 include(GNUInstallDirs)
 include(BuildConfig)
+include(SetCxxStandard)
+
+set_cxx_standard( 17 )
 
 otk_add_executable( ommBakingSimple
   simple.cpp

--- a/examples/CuOmmBaking/Viewer/CMakeLists.txt
+++ b/examples/CuOmmBaking/Viewer/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries( ommBakingViewer
   PUBLIC  
   OptiXToolkit::CuOmmBaking
   OptiXToolkit::Gui
+  OptiXToolkit::OptiXMemory
   OptiXToolkit::ShaderUtil
   OptiXToolkit::Util
   OptiX::OptiX

--- a/examples/CuOmmBaking/Viewer/CMakeLists.txt
+++ b/examples/CuOmmBaking/Viewer/CMakeLists.txt
@@ -4,10 +4,13 @@
 
 include(GNUInstallDirs)
 include(BuildConfig)
+include(embed_cuda)
 include(FetchGlad)
 include(FetchGlfw)
+include(SetCxxStandard)
 
-include(embed_cuda)
+set_cxx_standard( 17 )
+
 embed_cuda(
   CONST HEADER CuOmmBakingViewerKernelCuda.h
   OUTPUT_TARGET

--- a/examples/CuOmmBaking/Viewer/CuOmmBakingApp.cpp
+++ b/examples/CuOmmBaking/Viewer/CuOmmBakingApp.cpp
@@ -13,6 +13,7 @@
 #include <OptiXToolkit/Gui/Camera.h>
 #include <OptiXToolkit/Gui/GLDisplay.h>
 #include <OptiXToolkit/Gui/glfw3.h>
+#include <OptiXToolkit/OptiXMemory/CompileOptions.h>
 #include <OptiXToolkit/Util/Logger.h>
 
 #include <cuda_runtime.h>
@@ -134,11 +135,8 @@ void OmmBakingApp::createContext( PerDeviceOptixState& state )
 
 void OmmBakingApp::createModule( PerDeviceOptixState& state, const char* moduleCode, size_t codeSize )
 {
-    OptixModuleCompileOptions module_compile_options = {};
-#if !defined( NDEBUG )
-    module_compile_options.optLevel   = OPTIX_COMPILE_OPTIMIZATION_LEVEL_0;
-    module_compile_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
-#endif
+    OptixModuleCompileOptions module_compile_options{};
+    otk::configModuleCompileOptions( module_compile_options );
 
     state.pipeline_compile_options.usesMotionBlur        = false;
     state.pipeline_compile_options.traversableGraphFlags = OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_GAS;

--- a/examples/DemandLoading/DemandGeometryViewer/CMakeLists.txt
+++ b/examples/DemandLoading/DemandGeometryViewer/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries( DemandGeometryViewer PUBLIC
     DemandGeometryViewerKernel
     OptiXToolkit::DemandGeometry
     OptiXToolkit::DemandMaterial
+    OptiXToolkit::OptiXMemory
     OptiXToolkit::ShaderUtil
     OptiXToolkit::Gui
     OptiXToolkit::Util

--- a/examples/DemandLoading/DemandGeometryViewer/DemandGeometryViewer.cpp
+++ b/examples/DemandLoading/DemandGeometryViewer/DemandGeometryViewer.cpp
@@ -23,6 +23,7 @@
 #include <OptiXToolkit/Memory/DeviceBuffer.h>
 #include <OptiXToolkit/Memory/SyncVector.h>
 #include <OptiXToolkit/OptiXMemory/Builders.h>
+#include <OptiXToolkit/OptiXMemory/CompileOptions.h>
 #include <OptiXToolkit/OptiXMemory/Record.h>
 #include <OptiXToolkit/OptiXMemory/SyncRecord.h>
 #include <OptiXToolkit/ShaderUtil/vec_math.h>
@@ -411,14 +412,7 @@ static OptixModuleCompileOptions getCompileOptions()
 {
     OptixModuleCompileOptions compileOptions{};
     compileOptions.maxRegisterCount = OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT;
-#ifdef NDEBUG
-    bool debugInfo{ false };
-#else
-    bool debugInfo{ true };
-#endif
-    compileOptions.optLevel   = debugInfo ? OPTIX_COMPILE_OPTIMIZATION_LEVEL_0 : OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
-    compileOptions.debugLevel = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL : OPTIX_COMPILE_DEBUG_LEVEL_MINIMAL;
-
+    otk::configModuleCompileOptions( compileOptions );
     return compileOptions;
 }
 
@@ -453,14 +447,8 @@ void Application::createPipeline()
     const uint_t             maxTraceDepth = 1;
     OptixPipelineLinkOptions options{};
     options.maxTraceDepth = maxTraceDepth;
+    otk::configPipelineLinkOptions( options );
 
-#if OPTIX_VERSION < 70700
-#ifdef NDEBUG
-    options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_NONE;
-#else
-    options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
-#endif
-#endif
     OTK_ERROR_CHECK_LOG( optixPipelineCreate( m_context, &m_pipelineOpts, &options, m_programGroups.data(),
                                            m_programGroups.size(), LOG, &LOG_SIZE, &m_pipeline ) );
 

--- a/examples/DemandLoading/DemandPbrtScene/CMakeLists.txt
+++ b/examples/DemandLoading/DemandPbrtScene/CMakeLists.txt
@@ -3,11 +3,12 @@
 #
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 include(BuildConfig)
 include(embed_cuda)
+include(SetCxxStandard)
+
+set_cxx_standard(17)
 
 find_package(OptiX 7.5)
 if(NOT OptiX_FOUND OR OPTIX_VERSION VERSION_LESS 7.5)

--- a/examples/DemandLoading/DemandPbrtScene/ProgramGroups.cpp
+++ b/examples/DemandLoading/DemandPbrtScene/ProgramGroups.cpp
@@ -22,6 +22,7 @@
 #include <OptiXToolkit/Error/optixErrorCheck.h>
 #include <OptiXToolkit/ImageSource/ImageSource.h>
 #include <OptiXToolkit/OptiXMemory/Builders.h>
+#include <OptiXToolkit/OptiXMemory/CompileOptions.h>
 #include <OptiXToolkit/PbrtSceneLoader/SceneDescription.h>
 #include <OptiXToolkit/PbrtSceneLoader/SceneLoader.h>
 
@@ -46,13 +47,7 @@ static OptixModuleCompileOptions getCompileOptions()
 {
     OptixModuleCompileOptions compileOptions{};
     compileOptions.maxRegisterCount = OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT;
-#ifdef NDEBUG
-    bool debugInfo{ false };
-#else
-    bool debugInfo{ true };
-#endif
-    compileOptions.optLevel   = debugInfo ? OPTIX_COMPILE_OPTIMIZATION_LEVEL_0 : OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
-    compileOptions.debugLevel = debugInfo ? OPTIX_COMPILE_DEBUG_LEVEL_FULL : OPTIX_COMPILE_DEBUG_LEVEL_MINIMAL;
+    otk::configModuleCompileOptions( compileOptions );
 
     return compileOptions;
 }

--- a/examples/DemandLoading/Texture/CMakeLists.txt
+++ b/examples/DemandLoading/Texture/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries( demandLoadTexture
   OptiXToolkit::DemandLoading
   OptiXToolkit::Gui
   OptiXToolkit::ImageSources
+  OptiXToolkit::OptiXMemory
   OptiXToolkit::Util
   CUDA::cudart
   )

--- a/examples/DemandLoading/Texture/texture.cpp
+++ b/examples/DemandLoading/Texture/texture.cpp
@@ -16,6 +16,7 @@
 #include <OptiXToolkit/Gui/Camera.h>
 #include <OptiXToolkit/Gui/Window.h>
 #include <OptiXToolkit/ImageSources/ImageSources.h>
+#include <OptiXToolkit/OptiXMemory/CompileOptions.h>
 #include <OptiXToolkit/ShaderUtil/vec_math.h>
 #include <OptiXToolkit/Util/Logger.h>
 
@@ -227,11 +228,8 @@ void buildAccel( PerDeviceSampleState& state )
 
 void createModule( PerDeviceSampleState& state )
 {
-    OptixModuleCompileOptions module_compile_options = {};
-#if !defined( NDEBUG )
-    module_compile_options.optLevel   = OPTIX_COMPILE_OPTIMIZATION_LEVEL_0;
-    module_compile_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
-#endif
+    OptixModuleCompileOptions module_compile_options{};
+    otk::configModuleCompileOptions( module_compile_options );
 
     state.pipeline_compile_options.usesMotionBlur        = false;
     state.pipeline_compile_options.traversableGraphFlags = OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_GAS;

--- a/examples/OTKAppBase/CMakeLists.txt
+++ b/examples/OTKAppBase/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(OTKAppBase
   OptiXToolkit::DemandLoading
   OptiXToolkit::Gui
   OptiXToolkit::ImageSources
+  OptiXToolkit::OptiXMemory
   OptiXToolkit::ShaderUtil
   OptiXToolkit::Util
   imgui::imgui

--- a/examples/OTKAppBase/src/OTKApp.cpp
+++ b/examples/OTKAppBase/src/OTKApp.cpp
@@ -27,6 +27,8 @@
 #include <OptiXToolkit/Gui/Gui.h>
 #include <OptiXToolkit/Gui/glfw3.h>
 
+#include <OptiXToolkit/OptiXMemory/CompileOptions.h>
+
 #include <OptiXToolkit/ShaderUtil/vec_math.h>
 
 #include <OptiXToolkit/Util/Logger.h>
@@ -245,11 +247,8 @@ void OTKApp::copyGeometryToDevice()
 
 void OTKApp::createModule( OTKAppPerDeviceOptixState& state, const char* moduleCode, size_t codeSize )
 {
-    OptixModuleCompileOptions module_compile_options = {};
-#if !defined( NDEBUG )
-    module_compile_options.optLevel   = OPTIX_COMPILE_OPTIMIZATION_LEVEL_0;
-    module_compile_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
-#endif
+    OptixModuleCompileOptions module_compile_options{};
+    otk::configModuleCompileOptions( module_compile_options );
 
     state.pipeline_compile_options.usesMotionBlur        = false;
     state.pipeline_compile_options.traversableGraphFlags = OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_GAS;

--- a/examples/Simple/OtkHello/CMakeLists.txt
+++ b/examples/Simple/OtkHello/CMakeLists.txt
@@ -33,6 +33,7 @@ otk_add_executable( otkHello
 target_link_libraries( otkHello
   otkHelloKernel
   OptiXToolkit::Gui
+  OptiXToolkit::OptiXMemory
   OptiXToolkit::Util
   OptiX::OptiX
   CUDA::cuda_driver

--- a/examples/Simple/OtkHello/hello.cpp
+++ b/examples/Simple/OtkHello/hello.cpp
@@ -10,6 +10,7 @@
 #include <OptiXToolkit/Error/optixErrorCheck.h>
 #include <OptiXToolkit/Gui/CUDAOutputBuffer.h>
 #include <OptiXToolkit/Gui/Window.h>
+#include <OptiXToolkit/OptiXMemory/CompileOptions.h>
 #include <OptiXToolkit/Util/Logger.h>
 
 #include <optix.h>
@@ -106,11 +107,8 @@ int main( int argc, char* argv[] )
         OptixModule                 module                   = nullptr;
         OptixPipelineCompileOptions pipeline_compile_options = {};
         {
-            OptixModuleCompileOptions module_compile_options = {};
-#if !defined( NDEBUG )
-            module_compile_options.optLevel   = OPTIX_COMPILE_OPTIMIZATION_LEVEL_0;
-            module_compile_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
-#endif
+            OptixModuleCompileOptions module_compile_options{};
+            otk::configModuleCompileOptions( module_compile_options );
             pipeline_compile_options.usesMotionBlur        = false;
             pipeline_compile_options.traversableGraphFlags = OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_LEVEL_INSTANCING;
             pipeline_compile_options.numPayloadValues      = 2;


### PR DESCRIPTION
- Use a CMake function to set the C++ standard
- Use C++17 for code that uses CUB
- Use functions to set module compile and pipeline link options based on build configuration