### PR TITLE
Correct enum not handled warning from gcc

### DIFF
--- a/DemandLoading/ImageSource/Testing/include/OptiXToolkit/ImageSource/Testing/MockImageSource.h
+++ b/DemandLoading/ImageSource/Testing/include/OptiXToolkit/ImageSource/Testing/MockImageSource.h
@@ -54,6 +54,8 @@ inline std::ostream& operator<<( std::ostream& str, CUarray_format val )
         OUTPUT_ENUM( CU_AD_FORMAT_BC6H_SF16 );
         OUTPUT_ENUM( CU_AD_FORMAT_BC7_UNORM );
         OUTPUT_ENUM( CU_AD_FORMAT_BC7_UNORM_SRGB );
+    default:
+        break;
     }
     return str << "? (" << static_cast<int>( val ) << ')';
 }


### PR DESCRIPTION
CUDA is going to keep adding image formats, but the only ones we explicitly support are already covered by this switch statement.