### PR TITLE
Guard against creating mipmapped arrays that are too large to sample.

### DIFF
--- a/DemandLoading/DemandLoading/CMakeLists.txt
+++ b/DemandLoading/DemandLoading/CMakeLists.txt
@@ -74,6 +74,8 @@ otk_add_library( DemandLoading STATIC
   src/Util/CudaCallback.h
   src/Util/CudaContext.h
   src/Util/Math.h
+  src/Util/MipmappedArrayCheck.cpp
+  src/Util/MipmappedArrayCheck.h
   src/Util/MutexArray.h
   src/Util/NVTXProfiling.h
   src/Util/Stopwatch.h
@@ -138,6 +140,7 @@ source_group( "Header Files\\Implementation" FILES
   src/Util/CudaCallback.h
   src/Util/CudaContext.h
   src/Util/Math.h
+  src/Util/MipmappedArrayCheck.h
   src/Util/MutexArray.h
   src/Util/NVTXProfiling.h
   src/Util/Stopwatch.h

--- a/DemandLoading/DemandLoading/src/Textures/CascadeRequestHandler.cpp
+++ b/DemandLoading/DemandLoading/src/Textures/CascadeRequestHandler.cpp
@@ -25,7 +25,18 @@ namespace demandLoading {
 
 void CascadeRequestHandler::fillRequest( CUstream stream, unsigned int pageId )
 {
-    loadPage( stream, pageId, false );
+    try
+    {
+        loadPage( stream, pageId, false );
+    }
+    catch( const std::runtime_error& e )
+    {
+        // Report the failure (e.g. the grown texture is missing or too large to sample) through the
+        // logger instead of letting it propagate and terminate the worker thread.  Logged at level 0
+        // so it is reported regardless of the configured log level.  loadPage leaves the cascade page
+        // non-resident on failure, so the request will be retried.
+        DL_LOG( 0, e.what() );
+    }
 }
 
 void CascadeRequestHandler::loadPage( CUstream stream, unsigned int pageId, bool reloadIfResident )
@@ -55,14 +66,18 @@ void CascadeRequestHandler::loadPage( CUstream stream, unsigned int pageId, bool
     if( cascadeInfo.width >= backingInfo.width || ( cascadeInfo.width >= requestCascadeSize && cascadeInfo.height >= requestCascadeSize ) )
         return;
 
-    // Clear the backing image and page table entry on the device.
+    // Clear the backing image on the device.
     cascadeImage->setBackingImage( std::shared_ptr<imageSource::ImageSource>(nullptr) );
-    m_loader->setPageTableEntry( pageId, false, 0ULL );
 
     // Create a new cascadeImage and replace the current image with it.
     unsigned int newCascadeSize = requestCascadeSize;
     std::shared_ptr<imageSource::ImageSource> newCascadeImage( new imageSource::CascadeImage( backingImage, newCascadeSize ) );
     m_loader->replaceTexture( stream, samplerId, newCascadeImage, texture->getDescriptor(), true );
+
+    // Mark the cascade page resident only after the replacement succeeds.  If replaceTexture throws,
+    // the page is left non-resident so the cascade request will be retried rather than silently
+    // stranded as resident with a zero mapping.
+    m_loader->setPageTableEntry( pageId, false, 0ULL );
 }
 
 unsigned int CascadeRequestHandler::cascadeIdToSamplerId( unsigned int pageId )

--- a/DemandLoading/DemandLoading/src/Textures/DenseTexture.cpp
+++ b/DemandLoading/DemandLoading/src/Textures/DenseTexture.cpp
@@ -4,6 +4,7 @@
 
 #include "Textures/DenseTexture.h"
 #include "Util/ContextSaver.h"
+#include "Util/MipmappedArrayCheck.h"
 
 #include <OptiXToolkit/Error/ErrorCheck.h>
 #include <OptiXToolkit/Error/cuErrorCheck.h>
@@ -39,8 +40,11 @@ void DenseTexture::init( const TextureDescriptor& descriptor, const imageSource:
     m_array = masterArray;
     if( m_array.get() == nullptr )
     {
-        CUmipmappedArray* array = new CUmipmappedArray();
-        OTK_ERROR_CHECK( cuMipmappedArrayCreate( array, &ad, m_info.numMipLevels ) );
+        // createMipmappedArray throws (before any allocation) if the requested size exceeds the
+        // device sampling limit, so the heap allocation below happens only on success.
+        CUmipmappedArray handle{};
+        createMipmappedArray( &handle, &ad, m_info.numMipLevels );
+        CUmipmappedArray* array = new CUmipmappedArray( handle );
 
         // Reset m_array with a deleter for the mipmapped array
         m_array.reset( array, [this]( CUmipmappedArray* array ) {

--- a/DemandLoading/DemandLoading/src/Textures/SamplerRequestHandler.cpp
+++ b/DemandLoading/DemandLoading/src/Textures/SamplerRequestHandler.cpp
@@ -29,7 +29,17 @@ namespace demandLoading {
 
 void SamplerRequestHandler::fillRequest( CUstream stream, unsigned int pageId )
 {
-    loadPage( stream, pageId, false );
+    try
+    {
+        loadPage( stream, pageId, false );
+    }
+    catch( const std::runtime_error& e )
+    {
+        // Report the failure (e.g. missing/unreadable image, unsupported format, or a texture too
+        // large to sample) through the logger instead of letting it propagate and terminate the
+        // worker thread.  Logged at level 0 so it is reported regardless of the configured log level.
+        DL_LOG( 0, e.what() );
+    }
 }
 
 void SamplerRequestHandler::loadPage( CUstream stream, unsigned int pageId, bool reloadIfResident )

--- a/DemandLoading/DemandLoading/src/Textures/SparseTexture.cpp
+++ b/DemandLoading/DemandLoading/src/Textures/SparseTexture.cpp
@@ -4,6 +4,7 @@
 
 #include "Textures/SparseTexture.h"
 #include "Util/ContextSaver.h"
+#include "Util/MipmappedArrayCheck.h"
 
 #include <OptiXToolkit/Error/ErrorCheck.h>
 #include <OptiXToolkit/Error/cuErrorCheck.h>
@@ -59,7 +60,9 @@ void SparseArray::init( const imageSource::TextureInfo& info )
     ad.Format      = m_info.format;
     ad.NumChannels = m_info.numChannels;
     ad.Flags       = CUDA_ARRAY3D_SPARSE;
-    OTK_ERROR_CHECK( cuMipmappedArrayCreate( &m_array, &ad, nominalNumMipLevels ) );
+    // Guard against the 4 GiB device-sampling limit using the nominal mip count, which is the number
+    // of levels the array is actually created with.
+    createMipmappedArray( &m_array, &ad, nominalNumMipLevels );
 
     // Get sparse texture properties
     OTK_ERROR_CHECK( cuMipmappedArrayGetSparseProperties( &m_properties, m_array ) );

--- a/DemandLoading/DemandLoading/src/Util/MipmappedArrayCheck.cpp
+++ b/DemandLoading/DemandLoading/src/Util/MipmappedArrayCheck.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "Util/MipmappedArrayCheck.h"
+
+#include <OptiXToolkit/Error/cuErrorCheck.h>
+#include <OptiXToolkit/ImageSource/TextureInfo.h>
+
+#include <algorithm>
+#include <sstream>
+
+namespace demandLoading {
+
+// Bits per pixel, matching imageSource::getBitsPerPixel() semantics (including 3 -> 4 channel promotion).
+// Returned in bits (not bytes) so that sub-byte-per-pixel formats such as BC1/BC4 (4 bits/pixel) are not
+// truncated to zero; the byte conversion happens once, after multiplying by the texel count.
+static size_t bitsPerPixel( const CUDA_ARRAY3D_DESCRIPTOR& desc )
+{
+    const unsigned int numChannels = ( desc.NumChannels != 3 ) ? desc.NumChannels : 4;
+    return static_cast<size_t>( imageSource::getBitsPerChannel( desc.Format ) ) * numChannels;
+}
+
+size_t getMipmappedArrayPackedBytes( const CUDA_ARRAY3D_DESCRIPTOR& desc, unsigned int numMipLevels )
+{
+    const size_t bpp = bitsPerPixel( desc );
+
+    size_t totalBits = 0;
+    for( unsigned int level = 0; level < numMipLevels; ++level )
+    {
+        const size_t levelWidth  = std::max( size_t{ 1 }, desc.Width >> level );
+        const size_t levelHeight = std::max( size_t{ 1 }, desc.Height >> level );
+        totalBits += bpp * levelWidth * levelHeight;
+    }
+    return totalBits / imageSource::BITS_PER_BYTE;
+}
+
+bool isMipmappedArraySizeSupported( const CUDA_ARRAY3D_DESCRIPTOR& desc, unsigned int numMipLevels, std::string* reason )
+{
+    const size_t packedBytes = getMipmappedArrayPackedBytes( desc, numMipLevels );
+    if( packedBytes <= MAX_MIPMAPPED_ARRAY_BYTES )
+        return true;
+
+    if( reason != nullptr )
+    {
+        std::ostringstream ss;
+        ss << "Mipmapped array of " << desc.Width << "x" << desc.Height << " (format 0x" << std::hex << desc.Format
+           << std::dec << ", " << desc.NumChannels << " channels, " << numMipLevels << " mip levels) has a packed size of "
+           << packedBytes << " bytes, which exceeds the " << MAX_MIPMAPPED_ARRAY_BYTES
+           << " byte (4 GiB) device sampling limit. Coarse mip levels of such an array sample as zero (black) on the device.";
+        *reason = ss.str();
+    }
+    return false;
+}
+
+void createMipmappedArray( CUmipmappedArray* array, const CUDA_ARRAY3D_DESCRIPTOR* desc, unsigned int numMipLevels )
+{
+    std::string reason;
+    if( !isMipmappedArraySizeSupported( *desc, numMipLevels, &reason ) )
+        OTK_ERROR_CHECK_MSG( CUDA_ERROR_INVALID_VALUE, reason.c_str() );
+
+    OTK_ERROR_CHECK( cuMipmappedArrayCreate( array, desc, numMipLevels ) );
+}
+
+}  // namespace demandLoading

--- a/DemandLoading/DemandLoading/src/Util/MipmappedArrayCheck.h
+++ b/DemandLoading/DemandLoading/src/Util/MipmappedArrayCheck.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <cuda.h>
+
+#include <cstddef>
+#include <string>
+
+namespace demandLoading {
+
+/// Maximum total size (in bytes) of a mipmapped CUDA array whose mip levels can all be sampled
+/// correctly on the device.
+///
+/// CUDA addresses texels within a mipmapped array using a 32-bit byte offset, so any texel whose
+/// offset reaches 2^32 (4 GiB) samples as zero (black) on the device -- even though the array
+/// creates successfully and CPU readback works.  Because mip level 0 sits at offset 0 and coarser
+/// levels are packed at increasing offsets, the coarsest levels are the first to fail as the array
+/// grows.  This limit is the same for dense and sparse (CUDA_ARRAY3D_SPARSE) arrays.
+const size_t MAX_MIPMAPPED_ARRAY_BYTES = size_t{ 1 } << 32;
+
+/// Total packed size, in bytes, of a mipmapped array with the given descriptor and number of mip
+/// levels.  This is the sum over all levels of (bytes per pixel * level width * level height),
+/// computed in 64-bit arithmetic.  Bytes per pixel matches imageSource::getBitsPerPixel(), including
+/// its promotion of 3 channels to 4.
+size_t getMipmappedArrayPackedBytes( const CUDA_ARRAY3D_DESCRIPTOR& desc, unsigned int numMipLevels );
+
+/// Returns true if a mipmapped array with the given descriptor and number of mip levels can be
+/// sampled correctly on the device, i.e. its packed size does not exceed MAX_MIPMAPPED_ARRAY_BYTES.
+/// When the size is not supported and reason is non-null, a human-readable explanation is stored in
+/// *reason.
+bool isMipmappedArraySizeSupported( const CUDA_ARRAY3D_DESCRIPTOR& desc, unsigned int numMipLevels, std::string* reason = nullptr );
+
+/// Wrapper around cuMipmappedArrayCreate that guards against the 4 GiB device-sampling limit
+/// described above.  If the requested size is not supported, it throws (via OTK_ERROR_CHECK_MSG)
+/// with a descriptive message instead of silently creating an array whose coarse mip levels would
+/// sample as zero.  Otherwise it forwards to cuMipmappedArrayCreate and throws on any CUDA error.
+void createMipmappedArray( CUmipmappedArray* array, const CUDA_ARRAY3D_DESCRIPTOR* desc, unsigned int numMipLevels );
+
+}  // namespace demandLoading

--- a/DemandLoading/DemandLoading/tests/CMakeLists.txt
+++ b/DemandLoading/DemandLoading/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ otk_add_executable( testDemandLoading
   TestDeviceContextImpl.cpp
   TestDrawTexture.cu
   TestDrawTexture.h
+  TestMipmappedArraySize.cpp
   TestMutexArray.cpp
   TestPageTableManager.cpp
   TestPagingSystem.cpp

--- a/DemandLoading/DemandLoading/tests/CMakeLists.txt
+++ b/DemandLoading/DemandLoading/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ otk_add_executable( testDemandLoading
   TestPageTableManager.cpp
   TestPagingSystem.cpp
   TestPagingSystemKernels.cpp
+  TestRequestHandlerLogging.cpp
   TestSparseTexture.cpp
   TestSparseTexture.cu
   TestSparseTexture.h

--- a/DemandLoading/DemandLoading/tests/TestMipmappedArraySize.cpp
+++ b/DemandLoading/DemandLoading/tests/TestMipmappedArraySize.cpp
@@ -1,0 +1,289 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+// Tests for the guard against CUDA's 4 GiB mipmapped-array device-sampling limit
+// (see src/Util/MipmappedArrayCheck.h).  cuMipmappedArrayCreate succeeds for arrays whose packed
+// mip chain exceeds 2^32 bytes, but coarse mip levels of such arrays sample as zero on the device.
+// The guard rejects those sizes up front.
+
+#include "Textures/DenseTexture.h"
+#include "Textures/SparseTexture.h"
+#include "Util/MipmappedArrayCheck.h"
+#include "TestDrawTexture.h"
+
+#include <OptiXToolkit/DemandLoading/SparseTextureDevices.h>
+#include <OptiXToolkit/DemandLoading/TextureDescriptor.h>
+#include <OptiXToolkit/Error/cuErrorCheck.h>
+#include <OptiXToolkit/Error/cudaErrorCheck.h>
+#include <OptiXToolkit/ImageSource/ImageSource.h>
+#include <OptiXToolkit/ImageSource/TextureInfo.h>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace demandLoading;
+using namespace imageSource;
+
+namespace {
+
+CUDA_ARRAY3D_DESCRIPTOR makeDescriptor( size_t width, size_t height, CUarray_format format, unsigned int numChannels, bool sparse = false )
+{
+    CUDA_ARRAY3D_DESCRIPTOR ad{};
+    ad.Width       = width;
+    ad.Height      = height;
+    ad.Format      = format;
+    ad.NumChannels = numChannels;
+    ad.Flags       = sparse ? CUDA_ARRAY3D_SPARSE : 0;
+    return ad;
+}
+
+// Number of mip levels in the full chain down to 1x1 -- this is what real textures and the sparse
+// path (calculateNumMipLevels) use.
+unsigned int fullChainLevels( size_t width, size_t height )
+{
+    return calculateNumMipLevels( static_cast<unsigned int>( width ), static_cast<unsigned int>( height ) );
+}
+
+bool supportedFullChain( size_t width, size_t height, CUarray_format format, unsigned int numChannels )
+{
+    CUDA_ARRAY3D_DESCRIPTOR ad = makeDescriptor( width, height, format, numChannels );
+    return isMipmappedArraySizeSupported( ad, fullChainLevels( width, height ) );
+}
+
+}  // namespace
+
+//------------------------------------------------------------------------------
+// Predicate boundary tests (no allocation).
+//
+// Each pair straddles the 2^32-byte limit at adjacent dimensions over the full mip chain.  A check
+// that only looked at the base level (rather than the whole packed chain) would not flip between
+// these neighbors, so these pairs pin down that the guarded quantity is the packed chain size.
+//------------------------------------------------------------------------------
+
+TEST( TestMipmappedArraySize, Float4SquareBoundary )
+{
+    EXPECT_TRUE( supportedFullChain( 14189, 14189, CU_AD_FORMAT_FLOAT, 4 ) );
+    EXPECT_FALSE( supportedFullChain( 14190, 14190, CU_AD_FORMAT_FLOAT, 4 ) );
+}
+
+TEST( TestMipmappedArraySize, Half4SquareBoundary )
+{
+    EXPECT_TRUE( supportedFullChain( 20066, 20066, CU_AD_FORMAT_HALF, 4 ) );
+    EXPECT_FALSE( supportedFullChain( 20067, 20067, CU_AD_FORMAT_HALF, 4 ) );
+}
+
+TEST( TestMipmappedArraySize, LopsidedBoundary )
+{
+    // 32768 x 6144 float4 packs to exactly 16 bytes under 2^32; one more row of texels exceeds it.
+    EXPECT_TRUE( supportedFullChain( 32768, 6144, CU_AD_FORMAT_FLOAT, 4 ) );
+    EXPECT_FALSE( supportedFullChain( 32768, 6145, CU_AD_FORMAT_FLOAT, 4 ) );
+
+    // The same limit applies regardless of which dimension is large.
+    EXPECT_TRUE( supportedFullChain( 6144, 32768, CU_AD_FORMAT_FLOAT, 4 ) );
+    EXPECT_FALSE( supportedFullChain( 6145, 32768, CU_AD_FORMAT_FLOAT, 4 ) );
+}
+
+TEST( TestMipmappedArraySize, SingleChannelFormatsHaveHigherLimit )
+{
+    // 1-channel formats reach the limit at larger dimensions than their 4-channel counterparts,
+    // confirming the limit tracks bytes, not texel count. (float: ~28378, half: ~40132.)
+    EXPECT_TRUE( supportedFullChain( 28378, 28378, CU_AD_FORMAT_FLOAT, 1 ) );
+    EXPECT_FALSE( supportedFullChain( 28379, 28379, CU_AD_FORMAT_FLOAT, 1 ) );
+    EXPECT_TRUE( supportedFullChain( 16384, 16384, CU_AD_FORMAT_HALF, 1 ) );  // half1 16384^2 well under 4 GiB
+}
+
+// The guard must sum the whole packed chain, not just the base level.  float4 16384^2 has a base
+// level of exactly 2^32 bytes (supported on its own), but the full chain exceeds the limit.
+TEST( TestMipmappedArraySize, ChainVersusBaseLevel )
+{
+    CUDA_ARRAY3D_DESCRIPTOR ad = makeDescriptor( 16384, 16384, CU_AD_FORMAT_FLOAT, 4 );
+
+    EXPECT_EQ( MAX_MIPMAPPED_ARRAY_BYTES, getMipmappedArrayPackedBytes( ad, 1 ) );
+    EXPECT_TRUE( isMipmappedArraySizeSupported( ad, 1 ) );  // base level only
+
+    EXPECT_GT( getMipmappedArrayPackedBytes( ad, fullChainLevels( 16384, 16384 ) ), MAX_MIPMAPPED_ARRAY_BYTES );
+    EXPECT_FALSE( isMipmappedArraySizeSupported( ad, fullChainLevels( 16384, 16384 ) ) );
+}
+
+// Three-channel descriptors are counted as four channels, matching imageSource::getBitsPerPixel().
+TEST( TestMipmappedArraySize, ThreeChannelsCountedAsFour )
+{
+    CUDA_ARRAY3D_DESCRIPTOR threeCh = makeDescriptor( 1024, 1024, CU_AD_FORMAT_FLOAT, 3 );
+    CUDA_ARRAY3D_DESCRIPTOR fourCh  = makeDescriptor( 1024, 1024, CU_AD_FORMAT_FLOAT, 4 );
+    EXPECT_EQ( getMipmappedArrayPackedBytes( fourCh, 1 ), getMipmappedArrayPackedBytes( threeCh, 1 ) );
+}
+
+// Sub-byte-per-pixel block-compressed formats must not be truncated to zero bytes per pixel.
+// BC1 (4 channels x 1 bit) and BC4 (1 channel x 4 bits) are both 4 bits/pixel.
+TEST( TestMipmappedArraySize, BlockCompressedBytesNonZero )
+{
+    // 4096 x 4096 at 4 bits/pixel = 4096*4096*4/8 = 8,388,608 bytes for the base level.
+    const size_t expectedBaseBytes = size_t{ 4096 } * 4096 * 4 / 8;
+
+    CUDA_ARRAY3D_DESCRIPTOR bc1 = makeDescriptor( 4096, 4096, CU_AD_FORMAT_BC1_UNORM, 4 );
+    CUDA_ARRAY3D_DESCRIPTOR bc4 = makeDescriptor( 4096, 4096, CU_AD_FORMAT_BC4_UNORM, 1 );
+
+    EXPECT_GT( getMipmappedArrayPackedBytes( bc1, 1 ), size_t{ 0 } );
+    EXPECT_GT( getMipmappedArrayPackedBytes( bc4, 1 ), size_t{ 0 } );
+    EXPECT_EQ( expectedBaseBytes, getMipmappedArrayPackedBytes( bc1, 1 ) );
+    EXPECT_EQ( expectedBaseBytes, getMipmappedArrayPackedBytes( bc4, 1 ) );
+}
+
+//------------------------------------------------------------------------------
+// Wrapper rejection (no large allocation: the guard throws before cuMipmappedArrayCreate).
+//------------------------------------------------------------------------------
+
+TEST( TestMipmappedArraySize, CreateRejectsOversizedDense )
+{
+    OTK_ERROR_CHECK( cudaSetDevice( 0 ) );
+    OTK_ERROR_CHECK( cudaFree( nullptr ) );
+
+    CUDA_ARRAY3D_DESCRIPTOR ad = makeDescriptor( 16384, 16384, CU_AD_FORMAT_FLOAT, 4 );
+    CUmipmappedArray        array{};
+    EXPECT_THROW( createMipmappedArray( &array, &ad, fullChainLevels( 16384, 16384 ) ), std::runtime_error );
+}
+
+TEST( TestMipmappedArraySize, CreateRejectsOversizedSparse )
+{
+    const unsigned int deviceIndex = getFirstSparseTextureDevice();
+    if( deviceIndex == MAX_DEVICES )
+        GTEST_SKIP() << "No device supports sparse textures";
+    OTK_ERROR_CHECK( cudaSetDevice( deviceIndex ) );
+    OTK_ERROR_CHECK( cudaFree( nullptr ) );
+
+    CUDA_ARRAY3D_DESCRIPTOR ad = makeDescriptor( 16384, 16384, CU_AD_FORMAT_FLOAT, 4, /*sparse=*/true );
+    CUmipmappedArray        array{};
+    EXPECT_THROW( createMipmappedArray( &array, &ad, fullChainLevels( 16384, 16384 ) ), std::runtime_error );
+}
+
+//------------------------------------------------------------------------------
+// Real DenseTexture / SparseArray init paths.
+//------------------------------------------------------------------------------
+
+TEST( TestMipmappedArraySize, DenseTextureInitRejectsOversized )
+{
+    OTK_ERROR_CHECK( cudaSetDevice( 0 ) );
+    OTK_ERROR_CHECK( cudaFree( nullptr ) );
+
+    TextureDescriptor desc{};
+    desc.addressMode[0]   = CU_TR_ADDRESS_MODE_CLAMP;
+    desc.addressMode[1]   = CU_TR_ADDRESS_MODE_CLAMP;
+    desc.filterMode       = CU_TR_FILTER_MODE_POINT;
+    desc.mipmapFilterMode = CU_TR_FILTER_MODE_POINT;
+    desc.maxAnisotropy    = 1;
+
+    TextureInfo info{};
+    info.width        = 16384;
+    info.height       = 16384;
+    info.format       = CU_AD_FORMAT_FLOAT;
+    info.numChannels  = 4;
+    info.numMipLevels = fullChainLevels( 16384, 16384 );
+    info.isValid      = true;
+
+    DenseTexture texture;
+    EXPECT_THROW( texture.init( desc, info, nullptr ), std::runtime_error );
+}
+
+// The sparse path checks the nominal (full-chain) mip count, not info.numMipLevels.  With
+// numMipLevels == 1 a dense 16384^2 float4 texture is fine (base level == 2^32 bytes), but the
+// sparse array is created with the full nominal chain and must therefore be rejected.
+TEST( TestMipmappedArraySize, SparseUsesNominalMipCount )
+{
+    const unsigned int deviceIndex = getFirstSparseTextureDevice();
+    if( deviceIndex == MAX_DEVICES )
+        GTEST_SKIP() << "No device supports sparse textures";
+    OTK_ERROR_CHECK( cudaSetDevice( deviceIndex ) );
+    OTK_ERROR_CHECK( cudaFree( nullptr ) );
+
+    TextureInfo info{};
+    info.width        = 16384;
+    info.height       = 16384;
+    info.format       = CU_AD_FORMAT_FLOAT;
+    info.numChannels  = 4;
+    info.numMipLevels = 1;  // caller asks for a single level...
+    info.isValid      = true;
+
+    // ...dense honors that and the base level alone fits, so init succeeds.
+    {
+        TextureDescriptor desc{};
+        desc.addressMode[0]   = CU_TR_ADDRESS_MODE_CLAMP;
+        desc.addressMode[1]   = CU_TR_ADDRESS_MODE_CLAMP;
+        desc.filterMode       = CU_TR_FILTER_MODE_POINT;
+        desc.mipmapFilterMode = CU_TR_FILTER_MODE_POINT;
+        desc.maxAnisotropy    = 1;
+        DenseTexture dense;
+        EXPECT_NO_THROW( dense.init( desc, info, nullptr ) );
+    }
+
+    // ...but SparseArray creates the full nominal chain, which exceeds the limit, so it must throw.
+    {
+        SparseArray sparse;
+        EXPECT_THROW( sparse.init( info ), std::runtime_error );
+    }
+}
+
+//------------------------------------------------------------------------------
+// Small end-to-end happy path: an in-bounds dense texture still creates and samples correctly.
+//------------------------------------------------------------------------------
+
+TEST( TestMipmappedArraySize, SmallDenseTextureSamplesCorrectly )
+{
+    OTK_ERROR_CHECK( cudaSetDevice( 0 ) );
+    OTK_ERROR_CHECK( cudaFree( nullptr ) );
+
+    const unsigned int size = 256;  // ~256 KB base level, well within limits
+
+    TextureDescriptor desc{};
+    desc.addressMode[0]   = CU_TR_ADDRESS_MODE_CLAMP;
+    desc.addressMode[1]   = CU_TR_ADDRESS_MODE_CLAMP;
+    desc.filterMode       = CU_TR_FILTER_MODE_POINT;
+    desc.mipmapFilterMode = CU_TR_FILTER_MODE_POINT;
+    desc.maxAnisotropy    = 1;
+
+    TextureInfo info{};
+    info.width        = size;
+    info.height       = size;
+    info.format       = CU_AD_FORMAT_FLOAT;
+    info.numChannels  = 4;
+    info.numMipLevels = fullChainLevels( size, size );
+    info.isValid      = true;
+
+    DenseTexture texture;
+    ASSERT_NO_THROW( texture.init( desc, info, nullptr ) );
+
+    // Fill every mip level with a known color.
+    const float4 color = make_float4( 0.25f, 0.5f, 0.75f, 1.0f );
+    std::vector<float4> hostData( getTextureSizeInBytes( info ) / sizeof( float4 ), color );
+
+    CUstream stream;
+    OTK_ERROR_CHECK( cuStreamCreate( &stream, CU_STREAM_DEFAULT ) );
+    texture.fillTexture( stream, reinterpret_cast<const char*>( hostData.data() ), info.width, info.height, /*bufferPinned=*/false );
+    OTK_ERROR_CHECK( cuStreamSynchronize( stream ) );
+
+    // Sample the base level at the center of a 2x2 output image.
+    float4* devImage;
+    OTK_ERROR_CHECK( cudaMalloc( &devImage, 4 * sizeof( float4 ) ) );
+    launchDrawTextureKernel( stream, devImage, 2, 2, texture.getTextureObject(),
+                             make_float2( 0.f, 0.f ), make_float2( 1.f, 1.f ),
+                             make_float2( 0.f, 0.f ), make_float2( 0.f, 0.f ) );
+    OTK_ERROR_CHECK( cuStreamSynchronize( stream ) );
+
+    std::vector<float4> result( 4 );
+    OTK_ERROR_CHECK( cudaMemcpy( result.data(), devImage, 4 * sizeof( float4 ), cudaMemcpyDeviceToHost ) );
+
+    for( const float4& texel : result )
+    {
+        EXPECT_FLOAT_EQ( color.x, texel.x );
+        EXPECT_FLOAT_EQ( color.y, texel.y );
+        EXPECT_FLOAT_EQ( color.z, texel.z );
+        EXPECT_FLOAT_EQ( color.w, texel.w );
+    }
+
+    OTK_ERROR_CHECK( cudaFree( devImage ) );
+    OTK_ERROR_CHECK( cuStreamDestroy( stream ) );
+}

--- a/DemandLoading/DemandLoading/tests/TestRequestHandlerLogging.cpp
+++ b/DemandLoading/DemandLoading/tests/TestRequestHandlerLogging.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+// Verifies that a request handler reports a failed request through the existing logger (DL_LOG)
+// instead of letting the exception terminate the worker thread.  Without that handling the worker
+// thread dies before calling Ticket::notify(), so Ticket::wait() would never return -- hence the
+// test asserts both that wait() completes and that the error was captured by the logger.
+
+#include "TestSparseTexture.h"  // launchTextureDrawKernel
+#include "DemandLoaderImpl.h"
+
+#include <OptiXToolkit/DemandLoading/DemandLoadLogger.h>
+#include <OptiXToolkit/DemandLoading/DemandLoader.h>
+#include <OptiXToolkit/DemandLoading/DemandTexture.h>
+#include <OptiXToolkit/DemandLoading/SparseTextureDevices.h>
+#include <OptiXToolkit/DemandLoading/TextureDescriptor.h>
+#include <OptiXToolkit/Error/cuErrorCheck.h>
+#include <OptiXToolkit/Error/cudaErrorCheck.h>
+#include <OptiXToolkit/ImageSource/ImageSource.h>
+#include <OptiXToolkit/ImageSource/TextureInfo.h>
+
+#include <gtest/gtest.h>
+
+#include <cuda.h>
+
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace demandLoading;
+using namespace imageSource;
+
+namespace {
+
+// Thread-safe capturing log sink with static lifetime.  DemandLoadLogCallback is a raw function
+// pointer (no closure) invoked from worker threads, and DemandLoadLogger::setLogFunction is one-shot,
+// so the storage must be static + mutex-guarded and the installation must happen exactly once.
+std::mutex                               g_logMutex;
+std::vector<std::pair<int, std::string>> g_logMessages;
+
+void capturingLogCallback( int level, const char* message )
+{
+    std::lock_guard<std::mutex> lock( g_logMutex );
+    g_logMessages.emplace_back( level, message ? message : "" );
+}
+
+void installLoggerOnce()
+{
+    // Level 0 captures the errors the handlers report (DL_LOG level 0) while suppressing the
+    // level 4-5 informational traces.  The function-local static guarantees a single install even if
+    // the suite runs multiple test cases or is repeated.
+    static bool installed = [] {
+        DemandLoadLogger::setLogFunction( capturingLogCallback, 0 );
+        return true;
+    }();
+    (void)installed;
+}
+
+void clearLog()
+{
+    std::lock_guard<std::mutex> lock( g_logMutex );
+    g_logMessages.clear();
+}
+
+bool logContains( const std::string& substr, int& levelOut )
+{
+    std::lock_guard<std::mutex> lock( g_logMutex );
+    for( const auto& entry : g_logMessages )
+    {
+        if( entry.second.find( substr ) != std::string::npos )
+        {
+            levelOut = entry.first;
+            return true;
+        }
+    }
+    return false;
+}
+
+// An ImageSource whose open() always throws, simulating a missing or unreadable image file.
+class ThrowingImageSource : public ImageSourceBase
+{
+  public:
+    void open( TextureInfo* /*info*/ ) override { throw std::runtime_error( "simulated open failure" ); }
+    void close() override {}
+    bool isOpen() const override { return false; }
+    const TextureInfo& getInfo() const override { return m_info; }
+    CUmemorytype getFillType() const override { return CU_MEMORYTYPE_HOST; }
+    bool readTile( char*, unsigned int, const Tile&, CUstream ) override { return false; }
+    bool readMipLevel( char*, unsigned int, unsigned int, unsigned int, CUstream ) override { return false; }
+    bool readBaseColor( float4& ) override { return false; }
+
+  private:
+    TextureInfo m_info{};
+};
+
+}  // namespace
+
+class TestRequestHandlerLogging : public testing::Test
+{
+  public:
+    void SetUp() override
+    {
+        OTK_ERROR_CHECK( cuInit( 0 ) );
+        OTK_ERROR_CHECK( cudaFree( nullptr ) );
+
+        m_deviceIndex = getFirstSparseTextureDevice();
+        if( m_deviceIndex == MAX_DEVICES )
+            return;
+
+        OTK_ERROR_CHECK( cudaSetDevice( m_deviceIndex ) );
+        OTK_ERROR_CHECK( cudaStreamCreate( &m_stream ) );
+
+        Options options{};
+        m_loader.reset( new DemandLoaderImpl( options ) );
+
+        installLoggerOnce();
+        clearLog();
+    }
+
+    void TearDown() override
+    {
+        m_loader.reset();
+        if( m_stream )
+            OTK_ERROR_CHECK( cudaStreamDestroy( m_stream ) );
+    }
+
+  protected:
+    unsigned int                      m_deviceIndex = 0;
+    CUstream                          m_stream{};
+    std::unique_ptr<DemandLoaderImpl> m_loader;
+};
+
+// A sampler request whose image fails to open must be reported through the logger (at level 0) and
+// must not terminate the worker thread -- the request cycle still completes (ticket.wait() returns).
+TEST_F( TestRequestHandlerLogging, FailedSamplerRequestIsLogged )
+{
+    if( m_deviceIndex == MAX_DEVICES )
+        GTEST_SKIP() << "No device supports sparse textures";
+
+    TextureDescriptor desc{};
+    desc.addressMode[0]   = CU_TR_ADDRESS_MODE_CLAMP;
+    desc.addressMode[1]   = CU_TR_ADDRESS_MODE_CLAMP;
+    desc.filterMode       = CU_TR_FILTER_MODE_POINT;
+    desc.mipmapFilterMode = CU_TR_FILTER_MODE_POINT;
+    desc.maxAnisotropy    = 1;
+
+    std::shared_ptr<ImageSource> image = std::make_shared<ThrowingImageSource>();
+    const DemandTexture&         texture   = m_loader->createTexture( image, desc );
+    const unsigned int           textureId = texture.getId();
+
+    const int outWidth  = 16;
+    const int outHeight = 16;
+    float4*   devOutput;
+    OTK_ERROR_CHECK( cuMemAlloc( reinterpret_cast<CUdeviceptr*>( &devOutput ), outWidth * outHeight * sizeof( float4 ) ) );
+
+    // Drive a request for the texture's sampler; the worker calls open(), which throws.
+    for( int i = 0; i < 2; ++i )
+    {
+        DeviceContext context;
+        m_loader->launchPrepare( m_stream, context );
+        launchTextureDrawKernel( m_stream, context, textureId, devOutput, outWidth, outHeight );
+        Ticket ticket = m_loader->processRequests( m_stream, context );
+        ticket.wait();  // must return: the worker logged the error rather than dying before notify()
+    }
+
+    OTK_ERROR_CHECK( cuMemFree( reinterpret_cast<CUdeviceptr>( devOutput ) ) );
+
+    int level = -1;
+    EXPECT_TRUE( logContains( "simulated open failure", level ) );
+    EXPECT_EQ( 0, level );
+}

--- a/DemandLoading/DemandLoading/tests/TestSparseTextureWrap.cpp
+++ b/DemandLoading/DemandLoading/tests/TestSparseTextureWrap.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <math.h>
 #include <ostream>
+#include <stdexcept>
 
 using namespace demandLoading;
 using namespace imageSource;
@@ -294,7 +295,14 @@ TEST_F( TestSparseTextureWrap, largeTextures )
     if( m_deviceIndex == demandLoading::MAX_DEVICES )
         return;
 
-    testLargeSparseTexture( m_stream, 16384, 0, "largeSparse-16k-l0.ppm" );
-    testLargeSparseTexture( m_stream, 16384, 2, "largeSparse-16k-l2.ppm" );
+    // A 16384^2 float4 texture has a full mip chain of ~5.7 GB, which exceeds CUDA's 4 GiB
+    // mipmapped-array sampling limit. Such an array creates successfully but its coarse mip levels
+    // sample as black on the device, so the demand loader now rejects it at creation time.
+    EXPECT_THROW( testLargeSparseTexture( m_stream, 16384, 0, "largeSparse-16k-l0.ppm" ), std::runtime_error );
+    EXPECT_THROW( testLargeSparseTexture( m_stream, 16384, 2, "largeSparse-16k-l2.ppm" ), std::runtime_error );
+
+    // 14189^2 is the largest supported float4 square (its full mip chain stays just under 4 GiB),
+    // so creation and sampling -- including coarse mip levels -- succeed.
+    testLargeSparseTexture( m_stream, 14189, 2, "largeSparse-14k-l2.ppm" );
     testLargeSparseTexture( m_stream, 8194, 2, "largeSparse-8k-l2.ppm" );
 }


### PR DESCRIPTION
Guard against creating mipmapped arrays that are too large to sample.   Log this and other sampler request failures.