### PR TITLE
Clamp maxAnisotropy to 31 when creating a texture sampler.

### DIFF
--- a/DemandLoading/DemandLoading/include/OptiXToolkit/DemandLoading/TextureSampler.h
+++ b/DemandLoading/DemandLoading/include/OptiXToolkit/DemandLoading/TextureSampler.h
@@ -17,6 +17,7 @@ using CUtexObject = unsigned long long;
 namespace demandLoading {
 
 const unsigned int MAX_TILE_LEVELS = 9;
+const unsigned int MAX_STORABLE_ANISOTROPY = 31;
 
 /// Device-side texture info.
 struct TextureSampler

--- a/DemandLoading/DemandLoading/src/Textures/DemandTextureImpl.cpp
+++ b/DemandLoading/DemandLoading/src/Textures/DemandTextureImpl.cpp
@@ -189,7 +189,7 @@ void DemandTextureImpl::initSampler()
     m_sampler.desc.wrapMode0        = static_cast<int>( m_descriptor.addressMode[0] );
     m_sampler.desc.wrapMode1        = static_cast<int>( m_descriptor.addressMode[1] );
     m_sampler.desc.mipmapFilterMode = m_descriptor.mipmapFilterMode;
-    m_sampler.desc.maxAnisotropy    = m_descriptor.maxAnisotropy;
+    m_sampler.desc.maxAnisotropy    = std::min(m_descriptor.maxAnisotropy, MAX_STORABLE_ANISOTROPY);
 
     // Dimensions
     m_sampler.width             = m_info.width;


### PR DESCRIPTION
The hardware can typically do up to 16x anisotropy sampling, but some applications may want to increase this by software sampling. A typical max anisotropy is 32 for some applications, but the struct that holds the anisotropy value only uses 5 bits, and so has a max value of 31. Expanding the field is not an easy option because the struct TextureSampler::Description must be binary compatible with the struct passed in to the CUDA function tex2DGrad.  When a value >16 is specified as the as the anisotropy, the hardware samples it as 16x.  This is better than the previous behavior, which would wrap a 32x anisotropy to 0 and revert to isotropic sampling.
