### PR TITLE
Fix interactive rendering for cascading textures.

### DIFF
--- a/DemandLoading/DemandLoading/Testing/include/OptiXToolkit/DemandLoading/Testing/MockDemandLoader.h
+++ b/DemandLoading/DemandLoading/Testing/include/OptiXToolkit/DemandLoading/Testing/MockDemandLoader.h
@@ -37,6 +37,7 @@ class MockDemandLoader : public demandLoading::DemandLoader
     MOCK_METHOD( demandLoading::Ticket,
                  processRequests,
                  ( unsigned int deviceIndex, CUstream stream, const demandLoading::DeviceContext& deviceContext ) );
+    MOCK_METHOD( void, freeDeviceContext, ( demandLoading::DeviceContext& deviceContext ) );
     MOCK_METHOD( void, abort, () );
     MOCK_METHOD( demandLoading::Statistics, getStatistics, (), ( const ) );
     MOCK_METHOD( std::vector<unsigned int>, getDevices, (), ( const ) );

--- a/DemandLoading/DemandLoading/docs/README.md
+++ b/DemandLoading/DemandLoading/docs/README.md
@@ -240,9 +240,10 @@ ticket = demandLoader.processRequests(stream, deviceContext);
 Interactive applications that need to maintain a stable framerate should set `maxRequestedPages` to a lower value (such as 64 or 512), and poll the ticket rather than waiting on it. After an OptiX launch, the application should call `processRequests` to get a fresh batch of requests if the previous batch is done, or call `freeDeviceContext` to release the device memory reserved in launchPrepare:
 
 ```
+int numTasksRemaining = ticket.numTasksRemaining();
 demandLoader.launchPrepare(stream, deviceContext);
 optixLaunch(...);
-if( ticket.numTasksRemaining() == 0 ) {
+if( numTasksRemaining == 0 ) {
     ticket = demandLoader.processRequests(stream, deviceContext);
 }
 else {
@@ -255,6 +256,10 @@ Things to note for interactive workloads:
 - Calling `launchPrepare` before all requests are processed is fine. The call will update the page table with whatever requests have been filled, and the request processor will continue working on the batch.
 
 - `launchPrepare` allocates memory for a `DeviceContext` on the device. This memory must be freed by calling either `processRequests` or `freeDeviceContext` after the launch.
+
+- We recommend that interactive applications wait to call processRequests until the previous batch of requests is filled and the page table entries have been transferred to the device. To do this, get the number of tasks remaining *before* calling launchPrepare, and call processRequests again when this value is zero.
+
+- If an application wants to wait for the batch to complete more work before the next OptiX launch, it can do so before calling launchPrepare.
 
 - The length of the request queue is related to `maxRequestedPages`. If it is set too high, requests in the queue may move out of the frame before they are filled, wasting work.
 

--- a/DemandLoading/DemandLoading/src/Textures/SparseTexture.cpp
+++ b/DemandLoading/DemandLoading/src/Textures/SparseTexture.cpp
@@ -196,11 +196,15 @@ void SparseTexture::init( const TextureDescriptor& descriptor, const imageSource
     OTK_ERROR_CHECK( cuCtxGetCurrent( &m_context ) );
 
     // Set the array to a new array, or the master array if one was passed in
-    m_array = masterArray;
-    if( m_array.get() == nullptr )
+    m_oldArray = m_array; // Avoid destroying the old array immediately.
+    if( masterArray.get() == nullptr )
     {
         m_array.reset( new SparseArray() );
         m_array->init( m_info );
+    }
+    else
+    {
+        m_array = masterArray;
     }
 
     // Create CUDA texture descriptor

--- a/DemandLoading/DemandLoading/src/Textures/SparseTexture.h
+++ b/DemandLoading/DemandLoading/src/Textures/SparseTexture.h
@@ -155,6 +155,11 @@ class SparseTexture
     std::shared_ptr<SparseArray> m_array;
     CUtexObject                  m_texture{};
 
+    // A reference to the old array that the texture was using before being re-initialized.
+    // The array may be needed until the current batch of requests is complete. The reference
+    // keeps it from being destroyed immediately when the texture is replaced.
+    std::shared_ptr<SparseArray> m_oldArray;
+
     // Get the dimensions of the specified tile, which might be a partial tile.
     uint2 getTileDimensions( unsigned int mipLevel, unsigned int tileX, unsigned int tileY ) const;
 

--- a/examples/OTKAppBase/src/OTKApp.cpp
+++ b/examples/OTKAppBase/src/OTKApp.cpp
@@ -589,6 +589,9 @@ unsigned int OTKApp::performLaunches( )
         if( m_waitForTicket )
             state.ticket.wait();
 
+        // Get the number of tasks remaining before the launchPrepare call.
+        int numTasksRemaining = state.ticket.numTasksRemaining();
+
         // Call launchPrepare to synchronize new texture samplers and texture info to device memory.
         // launchPrepare also allocates device memory for a new demand texture context that can
         // be used to pull requests from the device.
@@ -615,10 +618,8 @@ unsigned int OTKApp::performLaunches( )
                                   1                                                 // launch depth
                                   ) );
 
-        // Poll the ticket to see if the previous batch of requests is filled. If the app waited
-        // on the ticket, it will be ready. If not, it may take several launches to fill all of
-        // the requests.
-        if( state.demandLoader && state.ticket.numTasksRemaining() == 0 )
+        // If the batch of requests was filled before calling launchPrepare, call processRequests to start a new batch.
+        if( state.demandLoader && numTasksRemaining == 0 )
         {
             numRequestsProcessed += static_cast<unsigned int>( state.ticket.numTasksTotal() );
             // Start an asynchronous pull of a new batch of requests from the device.


### PR DESCRIPTION
Cascading textures were crashing in interactive mode because the SparseArray was needed until the next launch.