### PR TITLE
Walk up the mip pyramid when a texture sample is not resident.

### DIFF
--- a/examples/DemandLoading/UdimTextureViewer/UdimTextureViewer.cpp
+++ b/examples/DemandLoading/UdimTextureViewer/UdimTextureViewer.cpp
@@ -199,7 +199,9 @@ void printUsage( const char* program )
         "   --file <outputfile>         Render to output file and exit.\n"
         "   --no-gl-interop             Disable OpenGL interop.\n"
         "   --log <level>               Set demand load log level (0-10)\n"
-        "   --wait-for-ticket           Wait for demand load ticket in interactive mode.\n";
+        "   --wait-for-ticket           Wait for demand load ticket in interactive mode.\n"
+        "   --max-requests <num>        Maximum number of requests per launch.\n"
+        "   --max-threads <num>         Maximum number of threads to process requests.\n";
     // clang-format on
 
     exit(0);
@@ -228,13 +230,15 @@ void printKeyCommands()
 
 int main( int argc, char* argv[] )
 {
-    int         windowWidth  = 768;
-    int         windowHeight = 768;
-    const char* textureName  = "mandelbrot";
-    const char* outFileName  = "";
-    bool        glInterop    = true;
-    int         logLevel     = 0;
+    int         windowWidth   = 768;
+    int         windowHeight  = 768;
+    const char* textureName   = "mandelbrot";
+    const char* outFileName   = "";
+    bool        glInterop     = true;
+    int         logLevel      = 0;
     bool        waitForTicket = false;
+    int         maxRequests   = 0;
+    int         maxThreads    = 0;
 
     int  texWidth = 8192;
     int  texHeight = 8192;
@@ -278,20 +282,27 @@ int main( int argc, char* argv[] )
             logLevel = atoi( argv[++i] );
         else if( arg == "--wait-for-ticket" )
             waitForTicket = true;
+        else if( arg == "--max-requests" && !lastArg )
+            maxRequests = atoi( argv[++i] );
+        else if( arg == "--max-threads" && !lastArg )
+            maxThreads = atoi( argv[++i] );
         else
             printUsage( argv[0] );
     }
 
     // Set up options for final frame or interactive rendering.
     bool interactive = strlen( outFileName ) == 0;
+    if( maxRequests <= 0 ) {
+        maxRequests = interactive ? 256 : 4096;
+    }
 
     options.maxTexMemPerDevice  = interactive ? 2ULL << 30 : 0ULL;
-    options.maxRequestedPages   = interactive ? 256 : 4096;
+    options.maxRequestedPages   = maxRequests;
     options.maxStalePages       = options.maxRequestedPages * 2;
     options.maxInvalidatedPages = options.maxRequestedPages * 2;
     options.maxStagedPages      = options.maxRequestedPages * 2;
     options.maxRequestQueueSize = options.maxRequestedPages * 2;
-    options.maxThreads          = 0;
+    options.maxThreads          = maxThreads;
 
     DemandLoadLogger::setLogFunction( standardDemandLoadLogCallback, logLevel );
     printKeyCommands();

--- a/examples/DemandLoading/UdimTextureViewer/UdimTextureViewer.cu
+++ b/examples/DemandLoading/UdimTextureViewer/UdimTextureViewer.cu
@@ -15,6 +15,25 @@ extern "C" {
 __constant__ OTKAppLaunchParams params;
 }
 
+template <class TYPE> __device__ __forceinline__ TYPE
+tex2DRetryBlend( const DeviceContext& context, unsigned int textureId, float x, float y, float2 ddx, float2 ddy, bool* isResident )
+{
+    // Walk up mip levels a few times
+    *isResident = false;
+    TYPE rval;
+    rval = tex2DGradUdimBlend<TYPE>( context, textureId, x, y, ddx*2.0f, ddy*2.0f, isResident );
+    if( *isResident ) return rval;
+    rval = tex2DGradUdimBlend<TYPE>( context, textureId, x, y, ddx*4.0f, ddy*4.0f, isResident );
+    if( *isResident ) return rval;
+    rval = tex2DGradUdimBlend<TYPE>( context, textureId, x, y, ddx*8.0f, ddy*8.0f, isResident );
+    if( *isResident ) return rval;
+
+    // Try the mip tail
+    rval = tex2DGradUdimBlend<TYPE>( context, textureId, x, y, float2{1.0f/32.0f, 0.0f}, float2{0.0f, 1.0f/32.0f}, isResident );
+    return rval;
+}
+
+
 //------------------------------------------------------------------------------
 // OptiX programs
 //------------------------------------------------------------------------------
@@ -45,13 +64,12 @@ extern "C" __global__ void __raygen__rg()
         float2 ddy = float2{0.0f, rayCone.width * uvdim->y};
         bool resident = false;
 
-        // Standard bilinear filtering
-        color = tex2DGradUdimBlend<float4>( params.demand_texture_context, params.display_texture_id,
-                                            u, v, ddx, ddy, &resident );
+        const DeviceContext& dtContext = params.demand_texture_context;
+        const unsigned int textureId = params.display_texture_id;
 
-        // Cubic filtering
-        //resident = textureUdim<float4>( params.demand_texture_context, params.display_texture_id,
-        //                                u, v, ddx, ddy, &color, nullptr, nullptr, float2{0.0f, 0.0f} );
+        color = tex2DGradUdimBlend<float4>( dtContext, textureId, u, v, ddx, ddy, &resident );
+        if( !resident )
+            color = tex2DRetryBlend<float4>( dtContext, textureId, u, v, ddx, ddy, &resident );
     }
     #endif
 
@@ -66,8 +84,9 @@ extern "C" __global__ void __raygen__rg()
     {
         bool resident = false;
         const SurfaceGeometry& g = prd.geometry;
-        color = tex2DGradUdimBlend<float4>( params.demand_texture_context, params.display_texture_id,
-                                            g.uv.x, g.uv.y, g.ddx, g.ddy, &resident );
+        color = tex2DGradUdimBlend<float4>( dtContext, textureId, u, v, ddx, ddy, &resident );
+        if( !resident )
+            color = tex2DRetryBlend<float4>( dtContext, textureId, u, v, ddx, ddy, &resident );
     }
     #endif
 

--- a/examples/OTKAppBase/include/OptiXToolkit/OTKAppBase/OTKApp.h
+++ b/examples/OTKAppBase/include/OptiXToolkit/OTKAppBase/OTKApp.h
@@ -122,6 +122,7 @@ class OTKApp
     bool                      m_useSparseTextures = true;
     bool                      m_useCascadingTextureSizes = false;
     bool                      m_waitForTicket = true;
+    bool                      m_pauseRequests = false;
 
     // Number of subframes to do
     int m_maxSubframes = 1000000;

--- a/examples/OTKAppBase/src/OTKApp.cpp
+++ b/examples/OTKAppBase/src/OTKApp.cpp
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include <chrono>
 #include <cmath>
 #include <iomanip>
 #include <iostream>
+#include <thread>
 
 #include <cuda_runtime.h>
 
@@ -590,6 +592,8 @@ unsigned int OTKApp::performLaunches( )
             state.ticket.wait();
 
         // Get the number of tasks remaining before the launchPrepare call.
+        if( state.ticket.numTasksRemaining() != 0 )
+            std::this_thread::sleep_for( std::chrono::milliseconds( 2 ) );
         int numTasksRemaining = state.ticket.numTasksRemaining();
 
         // Call launchPrepare to synchronize new texture samplers and texture info to device memory.
@@ -619,7 +623,7 @@ unsigned int OTKApp::performLaunches( )
                                   ) );
 
         // If the batch of requests was filled before calling launchPrepare, call processRequests to start a new batch.
-        if( state.demandLoader && numTasksRemaining == 0 )
+        if( state.demandLoader && numTasksRemaining == 0 && !m_pauseRequests )
         {
             numRequestsProcessed += static_cast<unsigned int>( state.ticket.numTasksTotal() );
             // Start an asynchronous pull of a new batch of requests from the device.
@@ -847,6 +851,8 @@ void OTKApp::keyCallback( GLFWwindow* window, int32_t key, int32_t /*scancode*/,
         initView();
     else if( key >= GLFW_KEY_0 && key <= GLFW_KEY_9 )
         m_render_mode = key - GLFW_KEY_0;
+    else if( key == GLFW_KEY_P )
+        m_pauseRequests = !m_pauseRequests;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Also, add command line args to control the max requests and max threads used by the demand loader.
This change supports experimentation about how to render textures interactively when the desired texture sample is not resident.