### PR TITLE
Add InverseSrgbImageSource

### DIFF
--- a/DemandLoading/ImageSource/CMakeLists.txt
+++ b/DemandLoading/ImageSource/CMakeLists.txt
@@ -20,6 +20,7 @@ otk_add_library( ImageSource STATIC
   src/DDSImageReader.cpp
   src/ImageSource.cpp
   src/ImageSourceCache.cpp
+  src/InverseSrgbImageSource.cpp
   src/MipMapImageSource.cpp
   src/RateLimitedImageSource.cpp
   src/Stopwatch.h
@@ -49,6 +50,7 @@ target_sources(ImageSource
   include/OptiXToolkit/ImageSource/ImageHelpers.h
   include/OptiXToolkit/ImageSource/ImageSource.h
   include/OptiXToolkit/ImageSource/ImageSourceCache.h
+  include/OptiXToolkit/ImageSource/InverseSrgbImageSource.h
   include/OptiXToolkit/ImageSource/MipMapImageSource.h
   include/OptiXToolkit/ImageSource/MultiCheckerImage.h
   include/OptiXToolkit/ImageSource/RateLimitedImageSource.h

--- a/DemandLoading/ImageSource/include/OptiXToolkit/ImageSource/InverseSrgbImageSource.h
+++ b/DemandLoading/ImageSource/include/OptiXToolkit/ImageSource/InverseSrgbImageSource.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <OptiXToolkit/ImageSource/TextureInfo.h>
+#include <OptiXToolkit/ImageSource/WrappedImageSource.h>
+
+#include <memory>
+
+namespace imageSource {
+
+/// Converts sRGB image pixels to linear floating-point values.
+///
+/// The first three channels are treated as color channels.  For two-channel
+/// images, only the first channel is treated as color; the second channel is
+/// preserved as alpha.  A fourth channel is likewise preserved as alpha.
+class InverseSrgbImageSource : public WrappedImageSource
+{
+  public:
+    explicit InverseSrgbImageSource( std::shared_ptr<ImageSource> imageSource );
+
+    void open( TextureInfo* info ) override;
+
+    void close() override;
+
+    const TextureInfo& getInfo() const override;
+
+    bool readTile( char* dest, unsigned int mipLevel, const Tile& tile, CUstream stream ) override;
+
+    bool readMipLevel( char* dest, unsigned int mipLevel, unsigned int expectedWidth, unsigned int expectedHeight, CUstream stream ) override;
+
+    bool readMipTail( char* dest, unsigned int mipTailFirstLevel, unsigned int numMipLevels, const uint2* mipLevelDims, CUstream stream ) override;
+
+    bool readBaseColor( float4& dest ) override;
+
+  private:
+    void getBaseInfo();
+    void convertPixels( const char* source, float* dest, size_t numPixels ) const;
+
+    TextureInfo m_baseInfo{};
+    TextureInfo m_info{};
+};
+
+std::shared_ptr<ImageSource> createInverseSrgbImageSource( std::shared_ptr<ImageSource> imageSource );
+
+}  // namespace imageSource

--- a/DemandLoading/ImageSource/src/InverseSrgbImageSource.cpp
+++ b/DemandLoading/ImageSource/src/InverseSrgbImageSource.cpp
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include <OptiXToolkit/ImageSource/InverseSrgbImageSource.h>
+
+#include <OptiXToolkit/ImageSource/TextureInfo.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace imageSource {
+
+namespace {
+
+float inverseSrgb( float value )
+{
+    return value <= 0.04045f ? value / 12.92f : std::pow( ( value + 0.055f ) / 1.055f, 2.4f );
+}
+
+float normalizationScale( CUarray_format format )
+{
+    switch( format )
+    {
+        case CU_AD_FORMAT_UNSIGNED_INT8:
+            return 1.0f / static_cast<float>( std::numeric_limits<std::uint8_t>::max() );
+        case CU_AD_FORMAT_UNSIGNED_INT16:
+            return 1.0f / static_cast<float>( std::numeric_limits<std::uint16_t>::max() );
+        case CU_AD_FORMAT_UNSIGNED_INT32:
+            return 1.0f / static_cast<float>( std::numeric_limits<std::uint32_t>::max() );
+        case CU_AD_FORMAT_FLOAT:
+            return 1.0f;
+        default:
+            throw std::runtime_error( "Unsupported pixel format for inverse sRGB conversion" );
+    }
+}
+
+float normalizedValue( const char* source, CUarray_format format )
+{
+    switch( format )
+    {
+        case CU_AD_FORMAT_UNSIGNED_INT8:
+            return static_cast<float>( *reinterpret_cast<const std::uint8_t*>( source ) ) * normalizationScale( format );
+        case CU_AD_FORMAT_UNSIGNED_INT16:
+            return static_cast<float>( *reinterpret_cast<const std::uint16_t*>( source ) ) * normalizationScale( format );
+        case CU_AD_FORMAT_UNSIGNED_INT32:
+            return static_cast<float>( *reinterpret_cast<const std::uint32_t*>( source ) ) * normalizationScale( format );
+        case CU_AD_FORMAT_FLOAT:
+            return *reinterpret_cast<const float*>( source );
+        default:
+            throw std::runtime_error( "Unsupported pixel format for inverse sRGB conversion" );
+    }
+}
+
+unsigned int colorChannelCount( unsigned int numChannels )
+{
+    return numChannels == 2 ? 1U : std::min( numChannels, 3U );
+}
+
+}  // namespace
+
+InverseSrgbImageSource::InverseSrgbImageSource( std::shared_ptr<ImageSource> imageSource )
+    : WrappedImageSource( std::move( imageSource ) )
+{
+    if( WrappedImageSource::isOpen() )
+    {
+        getBaseInfo();
+    }
+}
+
+void InverseSrgbImageSource::getBaseInfo()
+{
+    if( WrappedImageSource::getFillType() != CU_MEMORYTYPE_HOST )
+    {
+        throw std::runtime_error( "InverseSrgbImageSource requires a host-filled image source" );
+    }
+
+    m_baseInfo = WrappedImageSource::getInfo();
+    normalizationScale( m_baseInfo.format );
+    m_info        = m_baseInfo;
+    m_info.format = CU_AD_FORMAT_FLOAT;
+}
+
+void InverseSrgbImageSource::open( TextureInfo* info )
+{
+    if( !WrappedImageSource::isOpen() )
+    {
+        WrappedImageSource::open( nullptr );
+    }
+    getBaseInfo();
+    if( info != nullptr )
+    {
+        *info = m_info;
+    }
+}
+
+void InverseSrgbImageSource::close()
+{
+    WrappedImageSource::close();
+    m_baseInfo = TextureInfo{};
+    m_info     = TextureInfo{};
+}
+
+const TextureInfo& InverseSrgbImageSource::getInfo() const
+{
+    return m_info;
+}
+
+void InverseSrgbImageSource::convertPixels( const char* source, float* dest, size_t numPixels ) const
+{
+    const unsigned int bytesPerChannel{ getBitsPerChannel( m_baseInfo.format ) / BITS_PER_BYTE };
+    const unsigned int numColorChannels{ colorChannelCount( m_baseInfo.numChannels ) };
+    for( size_t pixel = 0; pixel < numPixels; ++pixel )
+    {
+        for( unsigned int channel = 0; channel < m_baseInfo.numChannels; ++channel )
+        {
+            const float value{ normalizedValue( source, m_baseInfo.format ) };
+            *dest++ = channel < numColorChannels ? inverseSrgb( value ) : value;
+            source += bytesPerChannel;
+        }
+    }
+}
+
+bool InverseSrgbImageSource::readTile( char* dest, unsigned int mipLevel, const Tile& tile, CUstream stream )
+{
+    const size_t baseSize{ static_cast<size_t>( tile.width ) * tile.height * getBitsPerPixel( m_baseInfo ) / BITS_PER_BYTE };
+    std::vector<char> basePixels( baseSize );
+    if( !WrappedImageSource::readTile( basePixels.data(), mipLevel, tile, stream ) )
+    {
+        return false;
+    }
+    convertPixels( basePixels.data(), reinterpret_cast<float*>( dest ), static_cast<size_t>( tile.width ) * tile.height );
+    return true;
+}
+
+bool InverseSrgbImageSource::readMipLevel( char* dest, unsigned int mipLevel, unsigned int expectedWidth, unsigned int expectedHeight, CUstream stream )
+{
+    const size_t      numPixels{ static_cast<size_t>( expectedWidth ) * expectedHeight };
+    const size_t      baseSize{ numPixels * getBitsPerPixel( m_baseInfo ) / BITS_PER_BYTE };
+    std::vector<char> basePixels( baseSize );
+    if( !WrappedImageSource::readMipLevel( basePixels.data(), mipLevel, expectedWidth, expectedHeight, stream ) )
+    {
+        return false;
+    }
+    convertPixels( basePixels.data(), reinterpret_cast<float*>( dest ), numPixels );
+    return true;
+}
+
+bool InverseSrgbImageSource::readMipTail( char* dest, unsigned int mipTailFirstLevel, unsigned int numMipLevels, const uint2* mipLevelDims, CUstream stream )
+{
+    size_t offset{};
+    for( unsigned int mipLevel = mipTailFirstLevel; mipLevel < numMipLevels; ++mipLevel )
+    {
+        const uint2 levelDims{ mipLevelDims[mipLevel] };
+        if( !readMipLevel( dest + offset, mipLevel, levelDims.x, levelDims.y, stream ) )
+        {
+            return false;
+        }
+        offset += static_cast<size_t>( levelDims.x ) * levelDims.y * getBitsPerPixel( m_info ) / BITS_PER_BYTE;
+    }
+    return true;
+}
+
+bool InverseSrgbImageSource::readBaseColor( float4& dest )
+{
+    float4 baseColor{};
+    if( !WrappedImageSource::readBaseColor( baseColor ) )
+    {
+        return false;
+    }
+
+    const unsigned int numColorChannels{ colorChannelCount( m_baseInfo.numChannels ) };
+    const float        scale{ normalizationScale( m_baseInfo.format ) };
+    float*             channels{ &baseColor.x };
+    for( unsigned int channel = 0; channel < m_baseInfo.numChannels; ++channel )
+    {
+        const float value{ channels[channel] * scale };
+        channels[channel] = channel < numColorChannels ? inverseSrgb( value ) : value;
+    }
+    dest = baseColor;
+    return true;
+}
+
+std::shared_ptr<ImageSource> createInverseSrgbImageSource( std::shared_ptr<ImageSource> imageSource )
+{
+    if( !imageSource )
+    {
+        return {};
+    }
+    return std::make_shared<InverseSrgbImageSource>( std::move( imageSource ) );
+}
+
+}  // namespace imageSource

--- a/DemandLoading/ImageSource/tests/CMakeLists.txt
+++ b/DemandLoading/ImageSource/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ otk_add_executable( testImageSource
   TestCascadeImage.cpp
   TestCheckerBoardImage.cpp
   TestImageSourceCache.cpp
+  TestInverseSrgbImageSource.cpp
   TestMipMapImageSource.cpp
   TestTiledImageSource.cpp
   ImageSourceTestConfig.h.in

--- a/DemandLoading/ImageSource/tests/TestInverseSrgbImageSource.cpp
+++ b/DemandLoading/ImageSource/tests/TestInverseSrgbImageSource.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include <OptiXToolkit/ImageSource/InverseSrgbImageSource.h>
+
+#include <OptiXToolkit/ImageSource/Testing/MockImageSource.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <vector_functions.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+using namespace imageSource;
+using namespace testing;
+
+namespace {
+
+float inverseSrgb( float value )
+{
+    return value <= 0.04045f ? value / 12.92f : std::pow( ( value + 0.055f ) / 1.055f, 2.4f );
+}
+
+class TestInverseSrgbImageSource : public Test
+{
+  protected:
+    void SetUp() override
+    {
+        m_baseInfo.width        = 2;
+        m_baseInfo.height       = 1;
+        m_baseInfo.format       = CU_AD_FORMAT_UNSIGNED_INT8;
+        m_baseInfo.numChannels  = 4;
+        m_baseInfo.numMipLevels = 1;
+        m_baseInfo.isValid      = true;
+        m_baseInfo.isTiled      = true;
+
+        EXPECT_CALL( *m_baseImage, isOpen() ).WillRepeatedly( Return( false ) );
+        m_image = std::make_shared<InverseSrgbImageSource>( m_baseImage );
+    }
+
+    void expectOpen()
+    {
+        EXPECT_CALL( *m_baseImage, open( IsNull() ) );
+        EXPECT_CALL( *m_baseImage, getFillType() ).WillOnce( Return( CU_MEMORYTYPE_HOST ) );
+        EXPECT_CALL( *m_baseImage, getInfo() ).WillOnce( ReturnRef( m_baseInfo ) );
+    }
+
+    void open()
+    {
+        expectOpen();
+        m_image->open( nullptr );
+    }
+
+    std::shared_ptr<otk::testing::MockImageSource> m_baseImage{ std::make_shared<otk::testing::MockImageSource>() };
+    TextureInfo                                    m_baseInfo{};
+    std::shared_ptr<InverseSrgbImageSource>        m_image;
+};
+
+}  // namespace
+
+TEST_F( TestInverseSrgbImageSource, reportsFloatPixelsAndPreservesImageShape )
+{
+    expectOpen();
+
+    TextureInfo info{};
+    m_image->open( &info );
+
+    EXPECT_EQ( CU_AD_FORMAT_FLOAT, info.format );
+    EXPECT_EQ( m_baseInfo.width, info.width );
+    EXPECT_EQ( m_baseInfo.height, info.height );
+    EXPECT_EQ( m_baseInfo.numChannels, info.numChannels );
+    EXPECT_EQ( m_baseInfo.numMipLevels, info.numMipLevels );
+    EXPECT_EQ( m_baseInfo.isTiled, info.isTiled );
+    EXPECT_EQ( info, m_image->getInfo() );
+}
+
+TEST_F( TestInverseSrgbImageSource, convertsTileRgbToLinearAndPreservesAlpha )
+{
+    open();
+    const std::vector<std::uint8_t> source{ 0U, 10U, 128U, 64U, 255U, 192U, 32U, 255U };
+    const Tile                      tile{ 0U, 0U, 2U, 1U };
+    EXPECT_CALL( *m_baseImage, readTile( NotNull(), 0U, tile, CUstream{} ) )
+        .WillOnce( DoAll( SetArrayArgument<0>( source.begin(), source.end() ), Return( true ) ) );
+    std::vector<float> result( source.size() );
+
+    ASSERT_TRUE( m_image->readTile( reinterpret_cast<char*>( result.data() ), 0U, tile, CUstream{} ) );
+
+    for( size_t i = 0; i < source.size(); ++i )
+    {
+        const float normalized{ static_cast<float>( source[i] ) / 255.0f };
+        const float expected{ i % 4U == 3U ? normalized : inverseSrgb( normalized ) };
+        EXPECT_FLOAT_EQ( expected, result[i] );
+    }
+}
+
+TEST_F( TestInverseSrgbImageSource, preservesSecondChannelOfTwoChannelImage )
+{
+    m_baseInfo.numChannels = 2;
+    open();
+    const std::vector<std::uint8_t> source{ 128U, 64U, 32U, 255U };
+    EXPECT_CALL( *m_baseImage, readMipLevel( NotNull(), 0U, 2U, 1U, CUstream{} ) )
+        .WillOnce( DoAll( SetArrayArgument<0>( source.begin(), source.end() ), Return( true ) ) );
+    std::vector<float> result( source.size() );
+
+    ASSERT_TRUE( m_image->readMipLevel( reinterpret_cast<char*>( result.data() ), 0U, 2U, 1U, CUstream{} ) );
+
+    EXPECT_FLOAT_EQ( inverseSrgb( 128.0f / 255.0f ), result[0] );
+    EXPECT_FLOAT_EQ( 64.0f / 255.0f, result[1] );
+    EXPECT_FLOAT_EQ( inverseSrgb( 32.0f / 255.0f ), result[2] );
+    EXPECT_FLOAT_EQ( 1.0f, result[3] );
+}
+
+TEST_F( TestInverseSrgbImageSource, convertsBaseColor )
+{
+    open();
+    EXPECT_CALL( *m_baseImage, readBaseColor( _ ) )
+        .WillOnce( DoAll( SetArgReferee<0>( make_float4( 128.0f, 64.0f, 32.0f, 255.0f ) ), Return( true ) ) );
+    float4 result{};
+
+    ASSERT_TRUE( m_image->readBaseColor( result ) );
+
+    EXPECT_FLOAT_EQ( inverseSrgb( 128.0f / 255.0f ), result.x );
+    EXPECT_FLOAT_EQ( inverseSrgb( 64.0f / 255.0f ), result.y );
+    EXPECT_FLOAT_EQ( inverseSrgb( 32.0f / 255.0f ), result.z );
+    EXPECT_FLOAT_EQ( 1.0f, result.w );
+}


### PR DESCRIPTION
If you have an ImageSource where source pixels are in sRGB space, but you need samples in linear color space, the InverseSrgbImageSource wrapper will map the source pixels to samples in linear color space.  A floating-point output is used to prevent excessive banding of the inverse colors.